### PR TITLE
Add Makefile + pre-commit + pinned black for local CI parity

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,10 @@ jobs:
       - name: Install linting dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 black
+          # Install dev extras so `black` is pinned to the version in
+          # pyproject.toml. Keep this in sync with .pre-commit-config.yaml
+          # and the local `make lint` target.
+          pip install -e ".[dev]"
 
       - name: Check code formatting with black
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ GWPvsStrength.png
 # Planning files
 *.plan.md
 
+# Local `make test-notebooks` output (executed copies of notebooks).
+.notebook-runs/
+
 # E2E / Playwright / Lighthouse CI
 node_modules/
 playwright-report/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# Local pre-commit hooks. Mirrors the CI lint gate in
+# .github/workflows/tests.yml so that "passes locally" implies
+# "passes the lint job on CI".
+#
+# One-time setup:
+#   pip install -e ".[dev]"     # installs pre-commit + pinned black
+#   pre-commit install          # registers the git hook
+#
+# Manual run across all tracked files (matches the CI invocation):
+#   pre-commit run --all-files
+repos:
+  - repo: https://github.com/psf/black
+    # Pinned to match the CI lint job. Keep this in sync with the
+    # `black==X.Y.Z` constraint in pyproject.toml's [project.optional-dependencies].dev.
+    rev: 26.3.1
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        # CI's hard gate: fail only on syntax errors / undefined names.
+        # Style warnings are reported but non-blocking on CI, and we keep
+        # the same posture locally to avoid pre-commit becoming a nag.
+        args:
+          - --count
+          - --select=E9,F63,F7,F82
+          - --show-source
+          - --statistics

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,66 @@ We actively welcome your pull requests.
 5. Make sure your code lints.
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
+## Running CI checks locally
+
+The repo has five GitHub Actions workflows in `.github/workflows/` that
+gate every PR. A `Makefile` exposes one target per workflow so "passes
+locally" implies "passes on CI". Run `make help` to list them all.
+
+### One-time setup
+
+```bash
+pip install -e ".[dev]"        # lint + Python unit tests + pre-commit
+pip install -e ".[notebooks]"  # for notebook execution / validation
+npm ci                         # for JS sync, e2e, lighthouse
+npx playwright install --with-deps chromium  # for e2e
+pre-commit install             # registers the git pre-commit hook
+```
+
+### Daily use
+
+```bash
+make check        # lint + fast tests (recommended pre-commit gate)
+make format       # apply black formatting in-place
+```
+
+`make check` runs (in seconds): black, flake8, pytest with the 100%
+coverage gate, the JS GP sync test, and notebook format validation.
+
+### Before pushing — full CI parity
+
+```bash
+make check-all    # everything `make check` runs PLUS:
+                  #   - execute every notebook (4-mode matrix)
+                  #   - Playwright (desktop + mobile)
+                  #   - Lighthouse CI
+```
+
+`make check-all` mirrors every workflow in `.github/workflows/` and is
+the right command to run before a force-push. It takes several minutes.
+
+### Individual targets
+
+| Target                    | Mirrors workflow                               |
+|---------------------------|------------------------------------------------|
+| `make lint`               | `tests.yml` :lint                              |
+| `make test-py`            | `tests.yml` :test                              |
+| `make test-js`            | `js-sync.yml`                                  |
+| `make test-notebook-fmt`  | `notebooks.yml` :notebook-lint                 |
+| `make test-notebooks`     | `notebooks.yml` :mode-{dependent,independent}  |
+| `make test-e2e`           | `e2e.yml`                                      |
+| `make test-lighthouse`    | `lighthouse.yml`                               |
+
+### Pre-commit hook
+
+`.pre-commit-config.yaml` runs the same `black` and `flake8` checks
+that `make lint` does, automatically on every commit. The black version
+is pinned to match `pyproject.toml` and the CI workflow.
+
+If you bump black, update all three in lockstep:
+`.pre-commit-config.yaml`, the `black==X.Y.Z` constraint in
+`pyproject.toml`, and re-run `make lint` to confirm.
+
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You only need
 to do this once to work on any of Facebook's open source projects.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,150 @@
+# Local CI-equivalent targets. Mirrors the suite of GitHub Actions
+# workflows in .github/workflows/ so that `make check-all` matches the
+# checks a PR will run on CI.
+#
+#   make help               - list targets
+#
+# === Fast (seconds) ===
+#   make lint               - black --check + flake8     (tests.yml :lint)
+#   make format             - apply black formatting in-place
+#   make test-py            - pytest with 100% coverage  (tests.yml :test)
+#   make test-js            - JS GP sync test            (js-sync.yml)
+#   make test-notebook-fmt  - nbformat validation        (notebooks.yml :notebook-lint)
+#
+# === Slow (minutes) ===
+#   make test-notebooks     - execute every notebook     (notebooks.yml :mode-*)
+#   make test-e2e           - Playwright desktop+mobile  (e2e.yml)
+#   make test-lighthouse    - Lighthouse CI              (lighthouse.yml)
+#
+# === Aggregates ===
+#   make test               - fast tests (py + js + notebook-fmt)
+#   make check              - lint + test          (recommended pre-commit gate)
+#   make check-all          - lint + every test    (full local CI parity)
+#
+# Most targets need extras installed:
+#   pip install -e ".[dev]"        # lint, test-py
+#   pip install -e ".[notebooks]"  # test-notebook-fmt, test-notebooks
+#   npm ci                         # test-js, test-e2e, test-lighthouse
+#   npx playwright install --with-deps chromium   # test-e2e
+
+PYTHON ?= python
+
+.PHONY: help \
+        lint format \
+        test-py test-js test-notebook-fmt test-notebooks \
+        test-e2e test-lighthouse \
+        test check check-all
+
+help:
+	@echo "Local CI-equivalent targets (see Makefile header for full list):"
+	@echo ""
+	@echo "  Fast:"
+	@echo "    make lint               - black --check + flake8"
+	@echo "    make format             - apply black formatting in-place"
+	@echo "    make test-py            - pytest with 100% coverage gate"
+	@echo "    make test-js            - JS GP sync test"
+	@echo "    make test-notebook-fmt  - nbformat validation"
+	@echo ""
+	@echo "  Slow:"
+	@echo "    make test-notebooks     - execute every notebook"
+	@echo "    make test-e2e           - Playwright (desktop + mobile)"
+	@echo "    make test-lighthouse    - Lighthouse CI"
+	@echo ""
+	@echo "  Aggregates:"
+	@echo "    make test               - fast tests"
+	@echo "    make check              - lint + test (recommended)"
+	@echo "    make check-all          - lint + every test (full CI parity)"
+
+# Tracked Python files. CI's `black --check --diff .` only sees files
+# in the checked-out commit, so locally we must scope to tracked files
+# too — otherwise an untracked work-in-progress script in the working
+# tree would block `make lint` even though it can't fail the PR. Falls
+# back from `sl files` (Sapling) to `git ls-files` (vanilla git).
+TRACKED_PY := $(shell (sl files 2>/dev/null || git ls-files) | grep -E '\.py$$')
+
+# --- Lint -----------------------------------------------------------
+# Mirrors .github/workflows/tests.yml :lint, scoped to TRACKED_PY so
+# untracked working-tree files don't poison the result. Black version
+# is pinned via pyproject.toml's [project.optional-dependencies].dev
+# so the formatter output is bit-for-bit identical to CI.
+lint:
+	$(PYTHON) -m black --check --diff $(TRACKED_PY)
+	$(PYTHON) -m flake8 $(TRACKED_PY) --count --select=E9,F63,F7,F82 --show-source --statistics
+	$(PYTHON) -m flake8 $(TRACKED_PY) --count --exit-zero --statistics
+
+format:
+	$(PYTHON) -m black $(TRACKED_PY)
+
+# --- Python unit tests ---------------------------------------------
+# Mirrors .github/workflows/tests.yml :test. We drop --cov-report=xml
+# because we don't need the coverage.xml artefact locally.
+test-py:
+	$(PYTHON) -m pytest test/ -v --tb=short --cov=boxcrete --cov-report=term-missing --cov-fail-under=100
+
+# --- JS GP sync test ------------------------------------------------
+# Mirrors .github/workflows/js-sync.yml. Verifies docs/gp.mjs predicts
+# the same values as the Python reference for the committed model.
+test-js:
+	node test/test_js_gp.mjs
+
+# --- Notebook format validation ------------------------------------
+# Mirrors .github/workflows/notebooks.yml :notebook-lint. Just validates
+# the JSON; does not execute the notebooks.
+test-notebook-fmt:
+	$(PYTHON) -c "import nbformat, pathlib; \
+nbs = sorted(pathlib.Path('notebooks').glob('*.ipynb')); \
+[(nbformat.read(open(p), as_version=4), print(f'OK {p}')) for p in nbs]; \
+print(f'Validated {len(nbs)} notebook(s).')"
+
+# --- Notebook execution --------------------------------------------
+# Mirrors .github/workflows/notebooks.yml :mode-{dependent,independent}.
+# Slow: each notebook runs nbconvert with a 600s timeout.
+# Mode-dependent notebooks are executed once per (mode, include-cost)
+# combination, matching the CI matrix.
+#
+# Unlike CI (which writes --inplace and uploads the executed notebook as
+# an artifact), we redirect output to a temp dir so the local working
+# copy isn't dirtied by `make` runs.
+NOTEBOOK_OUT := $(CURDIR)/.notebook-runs
+NBCONVERT := $(PYTHON) -m jupyter nbconvert --to notebook --execute \
+    --output-dir=$(NOTEBOOK_OUT) \
+    --ExecutePreprocessor.timeout=600 \
+    --ExecutePreprocessor.kernel_name=python3
+test-notebooks:
+	@mkdir -p $(NOTEBOOK_OUT)
+	BOXCRETE_OPTIMIZATION_MODE=concrete BOXCRETE_INCLUDE_COST=false \
+	    $(NBCONVERT) --output=mode_concrete_cost_false.ipynb \
+	    notebooks/prediction_and_optimization_tutorial.ipynb
+	BOXCRETE_OPTIMIZATION_MODE=concrete BOXCRETE_INCLUDE_COST=true \
+	    $(NBCONVERT) --output=mode_concrete_cost_true.ipynb \
+	    notebooks/prediction_and_optimization_tutorial.ipynb
+	BOXCRETE_OPTIMIZATION_MODE=mortar BOXCRETE_INCLUDE_COST=false \
+	    $(NBCONVERT) --output=mode_mortar_cost_false.ipynb \
+	    notebooks/prediction_and_optimization_tutorial.ipynb
+	BOXCRETE_OPTIMIZATION_MODE=mortar BOXCRETE_INCLUDE_COST=true \
+	    $(NBCONVERT) --output=mode_mortar_cost_true.ipynb \
+	    notebooks/prediction_and_optimization_tutorial.ipynb
+	@for nb in notebooks/*.ipynb; do \
+	    case "$$nb" in \
+	        notebooks/prediction_and_optimization_tutorial.ipynb) ;; \
+	        *) echo "=== Executing $$nb ==="; \
+	           $(NBCONVERT) "$$nb" ;; \
+	    esac \
+	done
+
+# --- E2E (Playwright) ----------------------------------------------
+# Mirrors .github/workflows/e2e.yml. Requires `npm ci` + a one-time
+# `npx playwright install --with-deps chromium` to set up browsers.
+test-e2e:
+	npx playwright test --project=desktop
+	npx playwright test --project=mobile
+
+# --- Lighthouse CI -------------------------------------------------
+# Mirrors .github/workflows/lighthouse.yml.
+test-lighthouse:
+	npx lhci autorun
+
+# --- Aggregates ----------------------------------------------------
+test: test-py test-js test-notebook-fmt
+check: lint test
+check-all: lint test-py test-js test-notebook-fmt test-notebooks test-e2e test-lighthouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,13 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black>=23.0.0",
+    # black is pinned (not >=) to keep formatter output bit-for-bit
+    # identical between contributors' machines and the CI lint job.
+    # Bumping requires updating .pre-commit-config.yaml and the
+    # `pip install` line in .github/workflows/tests.yml in lockstep.
+    "black==26.3.1",
     "flake8>=6.0.0",
+    "pre-commit>=3.0.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "parameterized>=0.9.0",


### PR DESCRIPTION
Brings every PR-blocking GitHub Actions check under a single `make` invocation so contributors can reproduce CI locally before pushing.

Why
---
The Tests workflow installs `black` via `pip install black` (latest available), which silently drifted from contributors' environments and caused two force-pushes on #20 to chase formatting fixes the local `black` couldn't see. CI also has four other workflows (js-sync, e2e, notebooks, lighthouse) with no documented local equivalent.

What
----
* `Makefile` with one target per workflow:
  - `lint` / `test-py` / `test-js` / `test-notebook-fmt` (fast)
  - `test-notebooks` / `test-e2e` / `test-lighthouse` (slow)
  - `check` = lint + fast tests; `check-all` = full CI parity.
* `.pre-commit-config.yaml` runs the same black + flake8 checks that CI does, automatically on every commit.
* `pyproject.toml`: black bumped from `>=23.0.0` to `==26.3.1` (the current CI version) and `pre-commit` added to `[dev]` extras.
* `.github/workflows/tests.yml`: lint job now `pip install -e ".[dev]"` so CI uses the pinned version too — eliminates the drift class of failure.
* `CONTRIBUTING.md`: one-time setup, daily-use, before-push, and a per-target table mapping each Make target to its CI workflow.

Bumping black requires updating .pre-commit-config.yaml + pyproject.toml
+ running `make lint` in lockstep.