### PR TITLE
Explorer: Embed video in an in-page overlay

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -104,7 +104,7 @@
     <span class="header-tagline">Interactive Concrete Strength Explorer</span>
     <nav class="header-links">
       <a href="#" id="about-link">About</a>
-      <a href="https://www.youtube.com/watch?v=PHuAG_jZMD8" target="_blank" rel="noopener">Video</a>
+      <a href="#" id="video-link">Video</a>
       <a href="https://github.com/facebookresearch/SustainableConcrete" target="_blank" rel="noopener">GitHub</a>
     </nav>
     <div class="header-actions">
@@ -127,7 +127,7 @@
   <!-- About Modal Overlay -->
   <div class="about-overlay" id="about-overlay">
     <div class="about-modal">
-      <button class="about-close" id="about-close" aria-label="Close">&times;</button>
+      <button class="about-close" aria-label="Close" data-modal-close>&times;</button>
       <h2>About This Explorer</h2>
       <p>This tool predicts concrete compressive strength using a Gaussian Process model trained on laboratory mortar and concrete specimens. Predictions reflect controlled lab conditions and <strong>may differ from field performance</strong> due to batching variability, curing environment, and aggregate properties.</p>
       <h3>How to Use</h3>
@@ -142,6 +142,20 @@
       <h3>Papers</h3>
       <p><a href="https://arxiv.org/abs/2603.21525" target="_blank" rel="noopener">Baten, Iqbal, Ament, Kusuma, &amp; Garg (2026)</a> — BOxCrete: A Bayesian Optimization Open-Source AI Model for Concrete Strength Forecasting and Mix Optimization.<br>
       <a href="https://arxiv.org/abs/2310.18288" target="_blank" rel="noopener">Ament, Witte, Garg, &amp; Kusuma (2023)</a> — Sustainable Concrete via Bayesian Optimization.</p>
+    </div>
+  </div>
+
+  <!-- Video Modal Overlay -->
+  <div class="video-overlay" id="video-overlay">
+    <div class="video-modal">
+      <button class="video-close" aria-label="Close" data-modal-close>&times;</button>
+      <div class="video-frame-wrap">
+        <iframe id="video-iframe"
+                title="BOxCrete video"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowfullscreen
+                referrerpolicy="strict-origin-when-cross-origin"></iframe>
+      </div>
     </div>
   </div>
 
@@ -417,20 +431,50 @@
       });
     }
 
+    // Generic modal: handles close button ([data-modal-close]), backdrop click,
+    // and Escape key. Optional onOpen/onClose hooks let callers run side effects
+    // (e.g. lazy-loading the video iframe).
+    function setupModal(overlay, { onOpen, onClose } = {}) {
+      const close = () => {
+        overlay.classList.remove('visible');
+        onClose?.();
+      };
+      const open = () => {
+        onOpen?.();
+        overlay.classList.add('visible');
+      };
+      for (const btn of overlay.querySelectorAll('[data-modal-close]')) {
+        btn.addEventListener('click', close);
+      }
+      overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) close();
+      });
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && overlay.classList.contains('visible')) close();
+      });
+      return { open, close };
+    }
+
     // About modal
-    const aboutOverlay = document.getElementById('about-overlay');
+    const aboutModal = setupModal(document.getElementById('about-overlay'));
     document.getElementById('about-link').addEventListener('click', (e) => {
       e.preventDefault();
-      aboutOverlay.classList.add('visible');
+      aboutModal.open();
     });
-    document.getElementById('about-close').addEventListener('click', () => {
-      aboutOverlay.classList.remove('visible');
+
+    // Video modal — iframe src is set on open (lazy load) and cleared on close
+    // (stops playback, frees player). Clearing is deferred until after the
+    // fade-out so users don't see a brief black flash where the video was.
+    const videoIframe = document.getElementById('video-iframe');
+    const VIDEO_EMBED_SRC = 'https://www.youtube-nocookie.com/embed/PHuAG_jZMD8?rel=0&autoplay=1';
+    const VIDEO_FADE_MS = 250; // matches .video-overlay opacity transition
+    const videoModal = setupModal(document.getElementById('video-overlay'), {
+      onOpen: () => { videoIframe.src = VIDEO_EMBED_SRC; },
+      onClose: () => { setTimeout(() => { videoIframe.src = ''; }, VIDEO_FADE_MS); },
     });
-    aboutOverlay.addEventListener('click', (e) => {
-      if (e.target === aboutOverlay) aboutOverlay.classList.remove('visible');
-    });
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') aboutOverlay.classList.remove('visible');
+    document.getElementById('video-link').addEventListener('click', (e) => {
+      e.preventDefault();
+      videoModal.open();
     });
   </script>
 </body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -312,6 +312,90 @@ body {
   .about-modal p, .about-modal li { font-size: 0.88rem; }
 }
 
+/* Video modal overlay (reuses about-overlay structure with wider 16:9 modal) */
+.video-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+.video-overlay.visible {
+  opacity: 1;
+  pointer-events: all;
+}
+.video-modal {
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 0.6rem;
+  width: min(960px, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  position: relative;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  transform: scale(0.95);
+  transition: transform 0.25s ease;
+}
+.video-overlay.visible .video-modal {
+  transform: scale(1);
+}
+/* Close button floats diagonally off the modal's top-right corner */
+.video-close {
+  position: absolute;
+  top: -1.6rem;
+  right: -1.6rem;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.4rem;
+  z-index: 1;
+  transition: color 0.15s, transform 0.15s;
+}
+.video-close:hover {
+  color: #fff;
+  transform: scale(1.1);
+}
+.video-frame-wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #000;
+}
+.video-frame-wrap iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+@media (max-width: 900px) {
+  .video-modal {
+    padding: 0.5rem;
+    width: calc(100vw - 1rem);
+    border-radius: 12px;
+  }
+  .video-close {
+    top: -2rem;
+    right: -0.25rem;
+  }
+}
+
 /* Theme toggle */
 .theme-toggle {
   background: rgba(var(--card-bg-rgb), 0.6);

--- a/test/e2e/about-modal.spec.ts
+++ b/test/e2e/about-modal.spec.ts
@@ -17,7 +17,7 @@ test.describe("about modal", () => {
     await expect(overlay).toHaveClass(/visible/);
     await expect(page.locator(".about-modal h2")).toBeVisible();
 
-    await page.locator("#about-close").click();
+    await page.locator(".about-overlay [data-modal-close]").click();
     await expect(overlay).not.toHaveClass(/visible/);
   });
 

--- a/test/e2e/header-layout.spec.ts
+++ b/test/e2e/header-layout.spec.ts
@@ -53,7 +53,7 @@ test.describe("header layout", () => {
     const selectors = [
       ".site-header h1",
       "#about-link",
-      'a[href*="youtube.com"]',
+      'a[href*="youtube.com"], #video-link',
       'a[href*="github.com/facebookresearch"]',
       ".theme-toggle",
     ];


### PR DESCRIPTION
Replaces the header **Video** link's external YouTube redirect with an
in-page modal overlay (same UX pattern as the existing **About** modal).
Visitors stay on the explorer page while watching.

## Implementation notes

- The iframe `src` is set on open (lazy load — no page-load cost) and
  cleared `250ms` after close (matches the overlay fade transition, so
  there's no black flash before the modal disappears).
- Modal wiring deduplicated into a generic `setupModal(overlay, { onOpen, onClose })`
  helper. Both About and Video modals share it. Close behavior is
  declarative: any descendant element with `[data-modal-close]` becomes
  a close button; backdrop click and Escape are handled centrally.
- Uses `youtube-nocookie.com` for the embed (privacy-enhanced).
- Removed deprecated `frameborder="0"` HTML attribute (CSS already
  enforces `border: 0`).