### PR TITLE
ci(notebooks): bump nbformat_minor to 5 and enforce schema validation

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -253,6 +253,12 @@ jobs:
               try:
                   with open(nb_path, 'r', encoding='utf-8') as f:
                       nb = nbformat.read(f, as_version=4)
+                  # `read` only checks parseability; `validate` enforces
+                  # the nbformat schema. Without this, schema mismatches
+                  # (e.g. cell `id` fields requiring nbformat_minor>=5)
+                  # only surface as ERROR-level log lines during the much
+                  # slower `nbconvert --execute` step and don't fail CI.
+                  nbformat.validate(nb)
                   print(f"✅ Valid notebook: {nb_path}")
               except Exception as e:
                   errors.append(f"❌ Invalid notebook {nb_path}: {e}")

--- a/notebooks/prediction_and_optimization_tutorial.ipynb
+++ b/notebooks/prediction_and_optimization_tutorial.ipynb
@@ -1329,5 +1329,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 2
+  "nbformat_minor": 5
 }

--- a/notebooks/slump_prediction_demo.ipynb
+++ b/notebooks/slump_prediction_demo.ipynb
@@ -376,5 +376,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 2
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
Two notebooks (prediction_and_optimization_tutorial, slump_prediction_demo) declared nbformat_minor=2 but contained per-cell 'id' fields, which were introduced in nbformat 4.5 (JEP 62). The 4.2 schema rejects them as unknown properties.

Symptom: 'jupyter nbconvert --execute' printed an ERROR-level log line during every Notebooks CI run, e.g.:

    [NbConvertApp] ERROR | Notebook JSON is invalid:
    Additional properties are not allowed ('id' was unexpected)

The execute step was non-fatal so this only manifested as log noise, but it masked the difference between a real and a benign failure mode.

Changes:
- notebooks/prediction_and_optimization_tutorial.ipynb: nbformat_minor 2 -> 5
- notebooks/slump_prediction_demo.ipynb:                nbformat_minor 2 -> 5
  (cell IDs were already valid 4.5-format UUIDs; only the declared schema
   version needed to catch up.)
- strength_curve_prediction_demo.ipynb is unchanged: it has no cell IDs
  and remains valid against the 4.2 schema.

- .github/workflows/notebooks.yml (notebook-lint job): add nbformat.validate(nb) after nbformat.read(...). 'read' only checks parseability; 'validate' enforces the schema and would have caught this mismatch in the fast lint job rather than as log noise during the slow execute step.

Verified locally: all 3 notebooks pass nbformat.validate, and a synthetic regression (re-introducing nbformat_minor=2 with cell IDs) is correctly rejected by the new validate() call.