### PR TITLE
Explorer uncertainty and strict lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,18 @@
 # E203, W503: black and flake8 disagree on whitespace/operator placement
 ignore = E203, W503
 max-line-length = 88
-exclude = build, dist, .eggs
+# When ``exclude`` is set explicitly it OVERRIDES flake8's defaults
+# (.svn, CVS, .bzr, .hg, .git, __pycache__, .tox, .eggs, *.egg) — so we
+# spell them out here. ``.git`` is critical: Sapling stores backup
+# copies of working-tree files under ``.git/sl/origbackups/`` and
+# without this exclude flake8 would lint them.
+exclude =
+    .git,
+    .hg,
+    .svn,
+    __pycache__,
+    .tox,
+    .eggs,
+    *.egg,
+    build,
+    dist,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,10 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          # Stop build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # Exit-zero treats all errors as warnings
+          # Hard gate: syntax errors, undefined names, unused imports /
+          # locals (real bugs), AND style violations (long lines,
+          # whitespace, etc.) — keeping local pre-commit and CI in sync
+          # so 'green locally' implies 'green on CI'.
+          flake8 . --count --select=E9,E202,E226,E251,E402,E501,E741,F401,F63,F7,F811,F82,F841 --show-source --statistics
+          # Exit-zero treats remaining E/W warnings as informational.
           flake8 . --count --exit-zero --statistics

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,11 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
-        # CI's hard gate: fail only on syntax errors / undefined names.
-        # Style warnings are reported but non-blocking on CI, and we keep
-        # the same posture locally to avoid pre-commit becoming a nag.
+        # Mirrors the CI lint gate in .github/workflows/tests.yml. Fails
+        # on the same codes CI fails on, so a successful local commit
+        # implies a green lint job upstream.
         args:
           - --count
-          - --select=E9,F63,F7,F82
+          - --select=E9,E202,E226,E251,E402,E501,E741,F401,F63,F7,F811,F82,F841
           - --show-source
           - --statistics

--- a/README.md
+++ b/README.md
@@ -235,5 +235,30 @@ For the earlier workshop paper that introduced the model with mortar data, pleas
 }
 ```
 
+## Development
+
+For local development, install with the `dev` extras and register the
+pre-commit hook so every `git commit` is auto-checked against the same
+lint gate the CI uses:
+
+```bash
+pip install -e ".[dev]"
+pre-commit install
+```
+
+`black` will auto-format whitespace, quoting, and most line wrapping on
+commit. `flake8` will fail the commit if it finds any of: syntax errors,
+undefined names, unused imports / locals, late imports, ambiguous names,
+or lines over 88 characters. To run the gate manually across the whole
+repo (matching CI):
+
+```bash
+pre-commit run --all-files
+```
+
+When adding a new long string literal or comment that black can't auto-
+split, hand-wrap it to ≤ 88 columns — the same convention BoTorch and
+GPyTorch use.
+
 ## License
 `SustainableConcrete` is released under the MIT license, as found in the LICENSE file.

--- a/boxcrete/concrete_model.py
+++ b/boxcrete/concrete_model.py
@@ -65,8 +65,9 @@ class SustainableConcreteModel:
             slump_model: The slump model. Defaults to None.
             cost_model: The cost model. Defaults to None.
             d: The dimensionality of the input to the strength model.
-                Is inferred automatically if the fit functions are called. NOTE: The model
-                assumes that the last element of the input corresponds to the time dimension.
+                Is inferred automatically if the fit functions are called.
+                NOTE: The model assumes that the last element of the input
+                corresponds to the time dimension.
         """
         self.strength_days = strength_days
         self.strength_model = strength_model
@@ -273,7 +274,8 @@ class SustainableConcreteModel:
         """
         if self.d is None or self.strength_model is None or self.gwp_model is None:
             raise ValueError(
-                "Model not fit yet. Call fit_gwp_model() and fit_strength_model() first."
+                "Model not fit yet. Call fit_gwp_model() and "
+                "fit_strength_model() first."
             )
 
         time_idx = self.d - 1  # last column is Time
@@ -330,7 +332,8 @@ class SustainableConcreteModel:
         """Ordered names of outputs in the ``ModelList`` from ``get_model_list``.
 
         Returns:
-            A list like ``["GWP", "1-day Strength", "28-day Strength", "Slump (in)", "Cost"]``.
+            A list like
+            ``["GWP", "1-day Strength", "28-day Strength", "Slump (in)", "Cost"]``.
         """
         names = ["GWP"]
         for day in self.strength_days:
@@ -363,7 +366,8 @@ class SustainableConcreteModel:
     ) -> dict[str, Model]:
         """Returns a name-to-model dictionary for the multi-output model.
 
-        Equivalent to ``dict(zip(model.model_names, model.get_model_list(...).models))``.
+        Equivalent to
+        ``dict(zip(model.model_names, model.get_model_list(...).models))``.
 
         Args:
             fixed_features: Same as ``get_model_list``.

--- a/boxcrete/features.py
+++ b/boxcrete/features.py
@@ -35,6 +35,8 @@ import torch
 from botorch.models.transforms.input import InputTransform
 from torch import Tensor
 
+from boxcrete.utils import DEFAULT_X_COLUMNS
+
 # Time gate constant: h(t) = 1 - exp(-t / GATE_TAU).
 # tau=0.05 (post-input-transform time units) was found to be optimal in
 # the τ-sweep; see §4.5 of the benchmark.
@@ -53,8 +55,6 @@ F5_ALLLOG_FEATURES = (
     "log_maturity_robust",
 )
 
-
-from boxcrete.utils import DEFAULT_X_COLUMNS
 
 # Short alias → full column name in :data:`boxcrete.utils.DEFAULT_X_COLUMNS`.
 # The integer indices in :data:`IDX` are *derived* from
@@ -176,10 +176,11 @@ def append_engineered_features_callable(
     """
 
     def f(X: torch.Tensor) -> torch.Tensor:
-        if (
-            not feature_names
-        ):  # pragma: no cover -- V2 fit always has F5_alllog (7 features); empty-feature_names branch only used by research-only ablations
-            return X.new_empty((*X.shape[:-1], 1, 0))
+        if not feature_names:
+            # ``pragma: no cover`` -- V2 fit always has F5_alllog
+            # (7 features); empty-feature_names branch only used by
+            # research-only ablations.
+            return X.new_empty((*X.shape[:-1], 1, 0))  # pragma: no cover
         feats = torch.cat([FEATURE_BUILDERS[n](X) for n in feature_names], dim=-1)
         return feats.unsqueeze(-2)
 
@@ -197,10 +198,11 @@ def max_scale_Y(Y: Tensor) -> tuple[Tensor, Tensor, Tensor]:
     Returns ``(Y_scaled, y_mean=0, y_std=y_max)`` so the existing untransform
     code path ``mean * y_std + y_mean`` works correctly.
     """
-    if (
-        Y.dim() == 1
-    ):  # pragma: no cover -- V2 callers pass [n, 1] Y (Y-shape guard at fit_strength_gp top); 1D fallback retained for symmetry with BoTorch's Standardize signature
-        Y = Y.unsqueeze(-1)
+    if Y.dim() == 1:
+        # ``pragma: no cover`` -- V2 callers pass [n, 1] Y (Y-shape
+        # guard at ``fit_strength_gp`` top); 1D fallback retained for
+        # symmetry with BoTorch's Standardize signature.
+        Y = Y.unsqueeze(-1)  # pragma: no cover
     y_max = Y.abs().max(dim=0, keepdim=True).values.clamp_min(1e-6)
     y_mean = torch.zeros_like(y_max)
     return Y / y_max, y_mean, y_max
@@ -215,10 +217,11 @@ def augmented_bounds(
     empirical [min, max] (with 5% padding) over the appended features
     evaluated on X.
     """
-    if (
-        not feature_names
-    ):  # pragma: no cover -- V2 fit always passes F5_alllog (7 features); empty-feature_names branch only used by research-only no-feature ablations
-        return bounds
+    if not feature_names:
+        # ``pragma: no cover`` -- V2 fit always passes F5_alllog
+        # (7 features); empty-feature_names branch only used by
+        # research-only no-feature ablations.
+        return bounds  # pragma: no cover
     appended_vals = torch.cat([FEATURE_BUILDERS[n](X) for n in feature_names], dim=-1)
     aug_lower = appended_vals.min(dim=0).values
     aug_upper = appended_vals.max(dim=0).values

--- a/boxcrete/kernels.py
+++ b/boxcrete/kernels.py
@@ -173,9 +173,11 @@ class TimeGatedKernel(Kernel):
         h2 = self._h(x2[..., self.time_idx])
         if diag:
             # K shape: [..., n] — element-wise multiply by h1, h2 (same shape)
-            return (
-                K * h1 * h2
-            )  # pragma: no cover -- diag=True kernel-eval branch; BoTorch's posterior(...).variance computes full covariance and extracts the diagonal, never calling kernel.forward with diag=True
+            # ``diag=True`` kernel-eval branch; BoTorch's
+            # ``posterior(...).variance`` computes the full covariance
+            # and extracts the diagonal, so kernel.forward is never
+            # called with diag=True in the production fit path.
+            return K * h1 * h2  # pragma: no cover
         # K shape: [..., n1, n2]; multiply by h1[...,n1,1] and h2[...,1,n2]
         return K * h1.unsqueeze(-1) * h2.unsqueeze(-2)
 

--- a/boxcrete/likelihoods.py
+++ b/boxcrete/likelihoods.py
@@ -128,10 +128,12 @@ class GatedGaussianLikelihood(_GaussianLikelihoodBase):
         noise_prior=None,
         **kwargs,
     ):
-        if (
-            noise_constraint is None
-        ):  # pragma: no cover -- production callers always pass an explicit noise_constraint via build_strength_kernel_for_aug_dim; this default-fallback path is research-only
-            noise_constraint = LogTransformedInterval(
+        if noise_constraint is None:
+            # ``pragma: no cover`` -- production callers always pass
+            # an explicit ``noise_constraint`` via
+            # ``build_strength_kernel_for_aug_dim``; this default-
+            # fallback path is research-only.
+            noise_constraint = LogTransformedInterval(  # pragma: no cover
                 1e-6,
                 1.0,
                 initial_value=1e-1,
@@ -161,9 +163,10 @@ class GatedGaussianLikelihood(_GaussianLikelihoodBase):
         doesn't proxy this automatically when we override
         ``_shaped_noise_covar`` with a ``HomoskedasticNoise`` placeholder,
         so we expose it explicitly here."""
-        return (
-            self.noise_covar.noise
-        )  # pragma: no cover -- exposed for notebook ergonomics; production fit/predict paths read self.noise_covar.noise directly
+        # ``pragma: no cover`` -- exposed for notebook ergonomics;
+        # production fit/predict paths read ``self.noise_covar.noise``
+        # directly.
+        return self.noise_covar.noise  # pragma: no cover
 
     def set_train_times(self, time_values: torch.Tensor) -> None:
         """Stash post-input-transform train times so the MLL path (which
@@ -193,8 +196,13 @@ class GatedGaussianLikelihood(_GaussianLikelihoodBase):
             t = params[0][..., self.time_idx]
         elif getattr(self, "_train_times", None) is not None:
             t = self._train_times
-        else:  # pragma: no cover -- defensive fallback; V2 fit always either passes a 2D X (training) or has _train_times set (eval) before this method is called
-            return super()._shaped_noise_covar(base_shape, *params, **kwargs)
+        else:
+            # ``pragma: no cover`` -- defensive fallback; V2 fit always
+            # either passes a 2D X (training) or has ``_train_times``
+            # set (eval) before this method is called.
+            return super()._shaped_noise_covar(  # pragma: no cover
+                base_shape, *params, **kwargs
+            )
         h = self._gate(t)
         h2 = h * h  # element-wise [n]
         # Scalar global noise (broadcasted to per-row).
@@ -203,9 +211,12 @@ class GatedGaussianLikelihood(_GaussianLikelihoodBase):
         n = int(base_shape[-1])
         if per_row_var.shape[0] >= n:
             per_row_var = per_row_var[:n]
-        else:  # pragma: no cover -- pad branch; V2 fit pre-sizes _train_times to match training data, so per_row_var.shape[0] always >= n
-            pad = sigma2.expand(n - per_row_var.shape[0])
-            per_row_var = torch.cat([per_row_var, pad], dim=0)
+        else:
+            # ``pragma: no cover`` -- pad branch; V2 fit pre-sizes
+            # ``_train_times`` to match training data, so
+            # ``per_row_var.shape[0]`` always >= n.
+            pad = sigma2.expand(n - per_row_var.shape[0])  # pragma: no cover
+            per_row_var = torch.cat([per_row_var, pad], dim=0)  # pragma: no cover
         return DiagLinearOperator(per_row_var)
 
 

--- a/boxcrete/plotting.py
+++ b/boxcrete/plotting.py
@@ -188,8 +188,8 @@ def compute_loo_cv(
     L = psd_safe_cholesky(K)
     residuals = (train_Y - prior_dist.mean).unsqueeze(-1)
     K_inv_res = torch.cholesky_solve(residuals, L)
-    I = torch.eye(n, dtype=L.dtype, device=L.device)
-    L_inv = torch.linalg.solve_triangular(L, I, upper=False)
+    eye_n = torch.eye(n, dtype=L.dtype, device=L.device)
+    L_inv = torch.linalg.solve_triangular(L, eye_n, upper=False)
     K_inv_diag = (L_inv**2).sum(dim=-2)
     loo_var = (1.0 / K_inv_diag).unsqueeze(-1)
     loo_mean = train_Y.unsqueeze(-1) - K_inv_res * loo_var

--- a/boxcrete/slump_model.py
+++ b/boxcrete/slump_model.py
@@ -17,13 +17,12 @@ Public API:
   * :func:`fit_slump_gp` — fit a slump GP on raw (X, Y, Yvar) data.
 
 The HRWR/binder ratio is appended via :class:`AppendDerivedFeatures`
-from :mod:`boxcrete.features` (the same transform :mod:`boxcrete.strength_model_legacy`'s
-V1 input transform composes with).
+from :mod:`boxcrete.features` (the same transform
+:mod:`boxcrete.strength_model_legacy`'s V1 input transform composes with).
 """
 
 from __future__ import annotations
 
-import torch
 from botorch import fit_gpytorch_mll
 from botorch.models import SingleTaskGP
 from botorch.models.transforms.input import ChainedInputTransform, Normalize

--- a/boxcrete/utils.py
+++ b/boxcrete/utils.py
@@ -272,8 +272,8 @@ class SustainableConcreteDataset:
             ).any():
                 logger.warning(  # pragma: no cover
                     "Bounds do not hold in training data: "
-                    f"{X_bounds[0, :], X.amin(dim=0) = }"
-                    f"{X_bounds[1, :], X.amax(dim=0) = }"
+                    f"{X_bounds[0, :], X.amin(dim=0)=}"
+                    f"{X_bounds[1, :], X.amax(dim=0)=}"
                 )
         return X, Y, Yvar, X_bounds
 
@@ -322,7 +322,8 @@ class SustainableConcreteDataset:
             raise ValueError(
                 "subselect_batch_names: this dataset was loaded without batch-"
                 "name indices. Re-load with "
-                "``load_concrete_strength(..., process_batch_names_from_mix_name=True)`` "
+                "``load_concrete_strength(..., "
+                "process_batch_names_from_mix_name=True)`` "
                 "or pass an explicit ``batch_name_to_indices`` dict."
             )
 
@@ -464,7 +465,7 @@ def load_concrete_strength(
             logger.info("  - %s has %s missing entries.", name, missing.item())
         logger.info("Removing missing rows with missing entries from data.")
         missing_row_ind = [i for i in range(len(df)) if is_missing[i].any()]
-        logger.info(f"  -Rows indices to be removed: {missing_row_ind = }")
+        logger.info(f"  -Rows indices to be removed: {missing_row_ind=}")
         df = df.drop(missing_row_ind)
         logger.info(
             "  -Number of missing values after deletion (Should be zero): "
@@ -866,8 +867,10 @@ def get_proportional_sum_constraints(
 
     Args:
         X_columns: The column (variable) names of the inputs `X`.
-        numerator_names: The subset of variable names whose sum to use as the numerator.
-        denominator_names: The subset of variable names whose sum to use as the denominator.
+        numerator_names: The subset of variable names whose sum to use as
+            the numerator.
+        denominator_names: The subset of variable names whose sum to use as
+            the denominator.
         lower: The lower limit of the fractional constraint.
         upper: The upper limit of the fractional constraint.
 
@@ -900,7 +903,8 @@ def get_proportional_sum_constraints(
 def get_subset_sum_tensors(
     X_columns: list[str], subset_names: list[str]
 ) -> tuple[list[int], Tensor]:
-    """Returns indices and coefficients such that `X[indices].dot(coeffs) == X[indices].sum()`,
+    """Returns indices and coefficients such that
+    `X[indices].dot(coeffs) == X[indices].sum()`,
     where indices are the indices of subset_names in X_columns.
 
     Args:
@@ -1064,8 +1068,10 @@ def get_day_zero_data(X: Tensor, n: int = 128):
     if n_unique <= n:
         # Use all unique compositions
         X_comps = unique_comps
-    else:  # pragma: no cover -- only triggered when training data has >n unique compositions; the strength dataset has 647 unique mixes < 128 default n
-        # Random subset of unique compositions
+    else:  # pragma: no cover
+        # Only triggered when training data has >n unique compositions;
+        # the strength dataset has 647 unique mixes < 128 default n.
+        # Random subset of unique compositions.
         perm = torch.randperm(n_unique)[:n]
         X_comps = unique_comps[perm]
 
@@ -1229,11 +1235,14 @@ def predict_pareto(
             interesting application of this function is to use different bounds to
             get quantitative results for "what-if" scenarios.
         equality_constraints: Equality constraints. Similar to the bounds, these can be
-            different than those used to train the model to explore "what-if" scenarios.
-        inequality_constraints: Inequality constraints. Similar to the bounds, these can
-            be different than those used to train the model to explore "what-if" scenarios.
-        num_candidates: The number of random inputs to generate in order to approximate
-            the Pareto frontier. The higher the number of candidates, the more accurate.
+            different than those used to train the model to explore
+            "what-if" scenarios.
+        inequality_constraints: Inequality constraints. Similar to the
+            bounds, these can be different than those used to train the
+            model to explore "what-if" scenarios.
+        num_candidates: The number of random inputs to generate in order
+            to approximate the Pareto frontier. The higher the number of
+            candidates, the more accurate.
 
     Returns:
         A 3-tuple of Tensors containing the predicted Pareto-optimal inputs, outputs and

--- a/docs/generate_mix_analyses.py
+++ b/docs/generate_mix_analyses.py
@@ -79,9 +79,7 @@ def generate_description(idx, comp):
     scm_pct = ((fly_ash + slag) / binder * 100) if has_binder else 0
     cement_pct = (cement / binder * 100) if has_binder else 0
     gwp = abs(gwp_preds[idx])
-    cost = abs(cost_preds[idx])
     str_28 = strength_preds["28"][idx]
-    str_1 = strength_preds["1"][idx]
     is_pareto = pareto_mask[idx] > 0.5
 
     # Observations
@@ -92,54 +90,85 @@ def generate_description(idx, comp):
         if 28 in day_vals and 1 in day_vals and day_vals[1] > 0:
             ratio = day_vals[28] / day_vals[1]
             if ratio > 5:
-                obs_str = f" Observed data shows remarkable late-age development \u2014 28-day strength is {ratio:.1f}\u00d7 the 1-day value, indicating significant pozzolanic reaction over time."
+                obs_str = (
+                    f" Observed data shows remarkable late-age development"
+                    f" \u2014 28-day strength is {ratio:.1f}\u00d7 the"
+                    f" 1-day value, indicating significant pozzolanic"
+                    f" reaction over time."
+                )
             elif ratio < 1.5 and day_vals[1] > 3000:
-                obs_str = f" This mix achieves most of its strength early \u2014 the 28/1-day ratio is only {ratio:.1f}\u00d7, suggesting rapid hydration dominates."
+                obs_str = (
+                    f" This mix achieves most of its strength early"
+                    f" \u2014 the 28/1-day ratio is only {ratio:.1f}\u00d7,"
+                    f" suggesting rapid hydration dominates."
+                )
             else:
-                obs_str = f" Strength develops steadily from {day_vals[1]:,.0f} psi at day 1 to {day_vals[28]:,.0f} psi at day 28."
+                obs_str = (
+                    f" Strength develops steadily from "
+                    f"{day_vals[1]:,.0f} psi at day 1 to "
+                    f"{day_vals[28]:,.0f} psi at day 28."
+                )
 
     parts = []
 
     # Title/summary
     if is_pareto:
         parts.append(
-            "**Pareto-optimal mix** — this formulation achieves an exceptional balance of strength and sustainability that no other tested mix dominates."
+            "**Pareto-optimal mix** \u2014 this formulation achieves an "
+            "exceptional balance of strength and sustainability that no "
+            "other tested mix dominates."
         )
 
     # Binder system description
     if scm_pct > 80:
         parts.append(
-            f"An ultra-high SCM replacement mix ({scm_pct:.0f}% supplementary cementitious materials), with only {cement:.0f} kg/m³ of Portland cement."
+            f"An ultra-high SCM replacement mix ({scm_pct:.0f}% "
+            f"supplementary cementitious materials), with only "
+            f"{cement:.0f} kg/m\u00b3 of Portland cement."
         )
     elif scm_pct > 60:
         parts.append(
-            f"A high-replacement mix using {scm_pct:.0f}% SCMs (fly ash + slag), significantly reducing clinker demand."
+            f"A high-replacement mix using {scm_pct:.0f}% SCMs (fly ash "
+            f"+ slag), significantly reducing clinker demand."
         )
     elif scm_pct > 30:
         parts.append(
-            f"A blended binder system with {scm_pct:.0f}% cement replacement by SCMs."
+            f"A blended binder system with {scm_pct:.0f}% cement "
+            f"replacement by SCMs."
         )
     elif cement > 600:
         parts.append(
-            f"A high-cement mix ({cement:.0f} kg/m³) with minimal SCM replacement — prioritizing early strength over sustainability."
+            f"A high-cement mix ({cement:.0f} kg/m\u00b3) with minimal "
+            f"SCM replacement \u2014 prioritizing early strength over "
+            f"sustainability."
         )
     else:
         parts.append(
-            f"A Portland cement–dominant mix ({cement_pct:.0f}% OPC) with {binder:.0f} kg/m³ total binder."
+            f"A Portland cement\u2013dominant mix ({cement_pct:.0f}% OPC) "
+            f"with {binder:.0f} kg/m\u00b3 total binder."
         )
 
     # SCM specifics
     if slag > 200 and fly_ash < 50:
         parts.append(
-            f"Slag dominates the SCM fraction at {slag:.0f} kg/m³, which contributes to denser pore structure and superior long-term strength development through latent hydraulic reaction."
+            f"Slag dominates the SCM fraction at {slag:.0f} kg/m\u00b3, "
+            f"which contributes to denser pore structure and superior "
+            f"long-term strength development through latent hydraulic "
+            f"reaction."
         )
     elif fly_ash > 200 and slag < 50:
         parts.append(
-            f"High fly ash content ({fly_ash:.0f} kg/m³) provides pozzolanic reactivity — consuming Ca(OH)₂ to form additional C-S-H gel. This delays early strength but improves workability and long-term durability."
+            f"High fly ash content ({fly_ash:.0f} kg/m\u00b3) provides "
+            f"pozzolanic reactivity \u2014 consuming Ca(OH)\u2082 to form "
+            f"additional C-S-H gel. This delays early strength but "
+            f"improves workability and long-term durability."
         )
     elif fly_ash > 100 and slag > 100:
         parts.append(
-            f"A ternary blend ({cement:.0f}/{fly_ash:.0f}/{slag:.0f} cement/fly ash/slag) leveraging synergies: slag provides hydraulic strength while fly ash improves particle packing and workability."
+            f"A ternary blend ({cement:.0f}/{fly_ash:.0f}/{slag:.0f} "
+            f"cement/fly ash/slag) leveraging synergies: slag provides "
+            f"hydraulic strength while fly ash improves particle "
+            f"packing and workability."
         )
 
     # W/B ratio
@@ -151,15 +180,21 @@ def generate_description(idx, comp):
         )
     elif wb < 0.25:
         parts.append(
-            f"Ultra-low W/B ratio ({wb:.3f}) enabled by {hrwr:.1f} kg/m\u00b3 of superplasticizer (HRWR). This produces an extremely dense matrix with minimal capillary porosity."
+            f"Ultra-low W/B ratio ({wb:.3f}) enabled by {hrwr:.1f} "
+            f"kg/m\u00b3 of superplasticizer (HRWR). This produces an "
+            f"extremely dense matrix with minimal capillary porosity."
         )
     elif wb < 0.35:
         parts.append(
-            f"Low W/B ratio ({wb:.3f}){' with HRWR for workability' if hrwr > 1 else ''} — targeting high strength through reduced porosity."
+            f"Low W/B ratio ({wb:.3f})"
+            f"{' with HRWR for workability' if hrwr > 1 else ''} \u2014 "
+            f"targeting high strength through reduced porosity."
         )
     elif wb > 0.5:
         parts.append(
-            f"Relatively high W/B ratio ({wb:.3f}) — this increases workability but introduces more capillary pores, limiting ultimate strength."
+            f"Relatively high W/B ratio ({wb:.3f}) \u2014 this increases "
+            f"workability but introduces more capillary pores, limiting "
+            f"ultimate strength."
         )
     else:
         parts.append(
@@ -169,28 +204,44 @@ def generate_description(idx, comp):
     # Temperature
     if temp < 0:
         parts.append(
-            f"Cured at {temp:.0f}°C — cold curing dramatically slows cement hydration and pozzolanic reactions. Early-age strength is severely compromised, though long-term strength may partially recover if curing conditions improve."
+            f"Cured at {temp:.0f}\u00b0C \u2014 cold curing dramatically "
+            f"slows cement hydration and pozzolanic reactions. Early-age "
+            f"strength is severely compromised, though long-term "
+            f"strength may partially recover if curing conditions improve."
         )
     elif temp == 10:
         parts.append(
-            f"Cured at {temp:.0f}°C — below the standard 22°C reference, which slows hydration kinetics and delays strength development, particularly for SCM-rich formulations."
+            f"Cured at {temp:.0f}\u00b0C \u2014 below the standard "
+            f"22\u00b0C reference, which slows hydration kinetics and "
+            f"delays strength development, particularly for SCM-rich "
+            f"formulations."
         )
 
     # Aggregate
     if coarse_agg > 0 and fine_agg > 0:
         ca_ratio = coarse_agg / (fine_agg + coarse_agg) * 100
+        descriptor = (
+            "coarse-dominant for structural applications"
+            if ca_ratio > 55
+            else "balanced gradation for workability"
+        )
         parts.append(
-            f"Aggregate blend: {ca_ratio:.0f}% coarse / {100-ca_ratio:.0f}% fine — {'coarse-dominant for structural applications' if ca_ratio > 55 else 'balanced gradation for workability'}."
+            f"Aggregate blend: {ca_ratio:.0f}% coarse / "
+            f"{100 - ca_ratio:.0f}% fine \u2014 {descriptor}."
         )
     elif coarse_agg == 0:
         parts.append(
-            "Fine-aggregate-only mix (no coarse aggregate) — a mortar-type formulation, common in laboratory screening studies."
+            "Fine-aggregate-only mix (no coarse aggregate) \u2014 a "
+            "mortar-type formulation, common in laboratory screening "
+            "studies."
         )
 
     # Material source
     if mat_source == 1:
         parts.append(
-            "Uses **Material Source B** — a different raw material supplier, which may affect reactivity and particle size distribution."
+            "Uses **Material Source B** \u2014 a different raw material "
+            "supplier, which may affect reactivity and particle size "
+            "distribution."
         )
 
     # Performance

--- a/docs/ui.mjs
+++ b/docs/ui.mjs
@@ -799,12 +799,16 @@ function updateReadouts() {
   document.getElementById("gwp-value").textContent =
     (Math.abs(gwp.mean) * u.gwpFactor).toFixed(1);
 
-  // Cost (with uncertainty)
+  // Cost (with uncertainty). Show ±2σ to match the strength-curve
+  // band convention; the explicit "(±2σ)" suffix tells users which
+  // confidence band they're seeing rather than leaving them to guess
+  // at the meaning of the bare ``±``.
   const cost = predictCost(compForGWP, costParams);
   const costMean = Math.abs(cost.mean) * u.costFactor;
   const costStd = Math.sqrt(cost.variance) * u.costFactor;
   document.getElementById("cost-value").textContent = costMean.toFixed(1);
-  document.getElementById("cost-uncertainty").textContent = `± ${costStd.toFixed(1)}`;
+  document.getElementById("cost-uncertainty").textContent =
+    `± ${(2 * costStd).toFixed(1)} (2σ)`;
 
   // W/B ratio
   const cols = compositionsData.column_names;
@@ -1185,6 +1189,30 @@ function drawStrengthCurve() {
   ctx.rotate(-Math.PI / 2);
   ctx.textAlign = "center";
   ctx.fillText(`Strength (${U().strength})`, 0, 0);
+  ctx.restore();
+
+  // Uncertainty-band legend (top-right corner, in-canvas). Tells
+  // viewers what the shaded band means without needing to open the
+  // About modal. Matches the ``± 2σ`` convention used by the cost
+  // readout and the About-text description.
+  ctx.save();
+  ctx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "top";
+  // Legend swatch (small filled rectangle in band color).
+  const swatchSize = 10;
+  const legendPadX = 8;
+  const legendPadY = 6;
+  const swatchX = W - pad.right - 70;
+  const swatchY = pad.top + legendPadY;
+  ctx.fillStyle = colors.band;
+  ctx.fillRect(swatchX, swatchY + 1, swatchSize, swatchSize);
+  ctx.fillStyle = colors.text;
+  ctx.fillText(
+    "shaded: ±2σ",
+    W - pad.right - legendPadX,
+    pad.top + legendPadY,
+  );
   ctx.restore();
 }
 

--- a/experiments/check_artifacts_drift.py
+++ b/experiments/check_artifacts_drift.py
@@ -136,8 +136,8 @@ class DriftCollector:
             rel = diff / max(abs(committed), 1.0)
             self.failures.append(
                 f"  {label}: committed={committed:.4f}, fresh={fresh:.4f}, "
-                f"abs={diff:.2f} psi ({rel*100:.2f}% rel; tol="
-                f"max({psi_floor:.0f}, {rtol*100:.1f}%)={delta:.2f})"
+                f"abs={diff:.2f} psi ({rel * 100:.2f}% rel; tol="
+                f"max({psi_floor:.0f}, {rtol * 100:.1f}%)={delta:.2f})"
             )
 
     def assert_variance_close(
@@ -154,9 +154,9 @@ class DriftCollector:
             rel = diff / max(abs(committed), 1.0)
             self.failures.append(
                 f"  {label}: committed={committed:.4f}, fresh={fresh:.4f}, "
-                f"abs={diff:.2f} psi^2 ({rel*100:.2f}% rel; tol="
+                f"abs={diff:.2f} psi^2 ({rel * 100:.2f}% rel; tol="
                 f"max({VARIANCE_PSI2_FLOOR:.0f}, "
-                f"{VARIANCE_RTOL*100:.1f}%)={delta:.2f})"
+                f"{VARIANCE_RTOL * 100:.1f}%)={delta:.2f})"
             )
 
 

--- a/experiments/regenerate_strength_json.py
+++ b/experiments/regenerate_strength_json.py
@@ -43,10 +43,10 @@ from boxcrete.utils import DEFAULT_X_COLUMNS, load_concrete_strength  # noqa: E4
 
 # F5_alllog feature names — order matters; matches Python's
 # F5_ALLLOG_FEATURES in boxcrete.features (single source of truth).
-from boxcrete.features import (
+from boxcrete.features import (  # noqa: E402
     F5_ALLLOG_FEATURES,
     GATE_TAU as _PROD_GATE_TAU,
-)  # noqa: E402
+)
 
 # pyrefly: ignore [missing-import]
 # ``_SOURCE_DIM`` is the index of the "Material Source" column in the
@@ -257,8 +257,9 @@ def main() -> None:
         "comment": (
             "V2 strength GP. Architecture: gated multi-Matern + 7 engineered "
             "features + Y/y_max scaling + ZeroMean + block-LOO HP refinement. "
-            "Block-LOO RMSE 665 psi at full data, phantom-anchor RMSE = 0 by construction. "
-            "See experiments/STRENGTH_GP_BENCHMARK.md for the full study."
+            "Block-LOO RMSE 665 psi at full data, phantom-anchor RMSE = 0 by "
+            "construction. See experiments/STRENGTH_GP_BENCHMARK.md for the "
+            "full study."
         ),
         # Dataset metadata
         "n_train": n_real,
@@ -327,7 +328,8 @@ def main() -> None:
     }
 
     print(
-        "[regenerate] Writing test vectors (multi-format) for JS-side regression checks…"
+        "[regenerate] Writing test vectors (multi-format) for JS-side "
+        "regression checks\u2026"
     )
     # 32 random training rows, picked uniformly across the dataset
     rng = torch.Generator().manual_seed(0)

--- a/test/test_lengthscale_identifiability.py
+++ b/test/test_lengthscale_identifiability.py
@@ -410,7 +410,7 @@ class TestStrengthLengthscaleIdentifiability(unittest.TestCase):
                     f"Fresh fit's prediction at OOT composition "
                     f"{v['composition']} (t={v['time']}d) differs from "
                     f"the committed test_vectors.json's expected_mean "
-                    f"by {abs_diff:.2f} psi ({rel_diff*100:.1f}% rel; "
+                    f"by {abs_diff:.2f} psi ({rel_diff * 100:.1f}% rel; "
                     f"tolerance was {delta:.2f} psi). This usually "
                     f"means a stale export — the model code or features "
                     f"changed but docs/model/*.json wasn't regenerated. "
@@ -422,7 +422,7 @@ class TestStrengthLengthscaleIdentifiability(unittest.TestCase):
         # Diagnostic on the worst case (always reported in logs).
         print(
             f"\n[test_committed_strength_matches_fresh_fit] worst case: "
-            f"{worst_abs:.2f} psi ({worst_rel*100:.2f}% rel) at "
+            f"{worst_abs:.2f} psi ({worst_rel * 100:.2f}% rel) at "
             f"{worst_label}"
         )
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -217,7 +217,7 @@ class TestSustainableConcreteModel(BaseModelTest):
             model.fit_slump_model(mock_data)
 
     def test_get_model_list_with_slump_and_fixed_features(self):
-        """Test model list wraps slump model when fixed_features has non-time entries."""
+        """Slump model wrapped when fixed_features has non-time entries."""
         n, d = 10, self.d - 1
         slump_model = SingleTaskGP(
             train_X=torch.rand(n, d, dtype=self.dtype),
@@ -409,8 +409,8 @@ class TestPredictiveQualityRegression(unittest.TestCase):
         L = psd_safe_cholesky(K)
         res = (train_Y - prior.mean).unsqueeze(-1)
         Kinv_res = torch.cholesky_solve(res, L)
-        I = torch.eye(n, dtype=L.dtype, device=L.device)
-        Linv = torch.linalg.solve_triangular(L, I, upper=False)
+        eye_n = torch.eye(n, dtype=L.dtype, device=L.device)
+        Linv = torch.linalg.solve_triangular(L, eye_n, upper=False)
         Kinv_diag = (Linv**2).sum(dim=-2)
         loo_var = (1.0 / Kinv_diag).unsqueeze(-1)
         loo_mean = train_Y.unsqueeze(-1) - Kinv_res * loo_var

--- a/test/test_partial_fixed_noise_likelihood.py
+++ b/test/test_partial_fixed_noise_likelihood.py
@@ -121,7 +121,6 @@ class TestPartialFixedNoiseLikelihood(unittest.TestCase):
         d = 3
         n_real = 15
         n_pseudo = 5
-        n_total = n_real + n_pseudo
 
         # Real observations
         X_real = torch.rand(n_real, d, dtype=torch.double)

--- a/test/test_strength_curve_monotonicity.py
+++ b/test/test_strength_curve_monotonicity.py
@@ -183,8 +183,9 @@ class TestStrengthCurveMonotonicity(unittest.TestCase):
             stats["frac_decreasing"],
             PASS_FRACTION_DECREASE,
             (
-                f"{label}: {100 * stats['frac_decreasing']:.1f}% of {stats['n_compositions']}"
-                f" compositions have decreasing intervals "
+                f"{label}: {100 * stats['frac_decreasing']:.1f}% of "
+                f"{stats['n_compositions']} compositions have decreasing "
+                f"intervals "
                 f"(threshold {100 * PASS_FRACTION_DECREASE:.0f}%). "
                 f"Strength curves should be monotone; this indicates "
                 f"the kernel has acquired pathological feature-time interactions."
@@ -195,17 +196,19 @@ class TestStrengthCurveMonotonicity(unittest.TestCase):
             stats["frac_oscillating_gt2"],
             PASS_FRACTION_OSCILLATE,
             (
-                f"{label}: {100 * stats['frac_oscillating_gt2']:.1f}% of compositions "
-                f"have > 2 inflection points (threshold {100 * PASS_FRACTION_OSCILLATE:.0f}%). "
-                f"This indicates the predictive mean is wiggling at intermediate times."
-                + msg_extra
+                f"{label}: {100 * stats['frac_oscillating_gt2']:.1f}% of "
+                f"compositions have > 2 inflection points (threshold "
+                f"{100 * PASS_FRACTION_OSCILLATE:.0f}%). "
+                f"This indicates the predictive mean is wiggling at "
+                f"intermediate times." + msg_extra
             ),
         )
         self.assertLess(
             stats["max_dropdown_psi"],
             PASS_MAX_DROP_PSI,
             (
-                f"{label}: worst single-step dropdown is {stats['max_dropdown_psi']:.0f} psi "
+                f"{label}: worst single-step dropdown is "
+                f"{stats['max_dropdown_psi']:.0f} psi "
                 f"(threshold {PASS_MAX_DROP_PSI:.0f} psi). "
                 f"This is well above measurement noise and clearly unphysical."
                 + msg_extra

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -676,7 +676,7 @@ class TestReduceToOptimizationSpace(unittest.TestCase):
         self.assertIs(out_ineq, ineq)
 
     def test_reduces_bounds_remaps_constraints_absorbs_values(self):
-        """Bounds are reduced, constraint indices remapped, and fixed values absorbed."""
+        """Bounds reduced, constraint indices remapped, fixed values absorbed."""
         bounds = torch.tensor([[0.0] * 4, [10.0] * 4])
         # eq: 2*x[0] + 3*x[1] + 4*x[2] + 5*x[3] = 100
         eq = [(torch.tensor([0, 1, 2, 3]), torch.tensor([2.0, 3.0, 4.0, 5.0]), 100.0)]


### PR DESCRIPTION
# Explorer uncertainty consistency + strict-lint hardening

Two cleanups following the V2 strength GP open-source PR.

## 1. Consistent ±2σ uncertainty in the explorer (`f974a55`)

The strength-curve plot has always shaded `mean ± 2σ`, but the cost readout displayed `± 1σ` — same `±` symbol, two different conventions in the same view.

- `docs/ui.mjs::updateUI` — cost readout now reads `± {2σ value} (2σ)`.
- `docs/ui.mjs::drawStrengthCurve` — adds a small on-canvas `shaded: ±2σ` legend in the plot's top-right corner.
- About-modal text already documented `±2σ` for the band — kept as-is, now consistent end-to-end.

## 2. Strict-lint hardening + dev-onboarding (`3a7e82f`)

CI's flake8 strict-select now covers the full set of bug-detector and key style codes (matching BoTorch/GPyTorch's 88-char convention):

| Code | What it catches |
|---|---|
| `E9, F63, F7, F82` | syntax errors, undefined names |
| `F401, F811, F841` | unused imports / redefinitions / unused locals |
| `E202` | whitespace before `}` |
| `E226` | missing whitespace around arithmetic operator |
| `E251` | unexpected spaces around keyword/parameter equals |
| `E402` | module-level import not at top of file |
| `E501` | line too long (88 chars) |
| `E741` | ambiguous variable name (`I` / `l` / `O`) |

### Files modified to conform

- **`boxcrete/slump_model.py`** — drop unused `import torch`.
- **`docs/generate_mix_analyses.py`** — drop unused `cost`/`str_1` locals; wrap ~20 long f-strings.
- **`test/test_partial_fixed_noise_likelihood.py`** — drop unused `n_total`.
- **`boxcrete/features.py`** — move `from boxcrete.utils import DEFAULT_X_COLUMNS` to top of module (E402); wrap 3 long lambda-builder lines.
- **`experiments/regenerate_strength_json.py`** — relocate `# noqa: E402` to opening line of multi-line import; wrap 2 long print lines.
- **`boxcrete/plotting.py:191`** + **`test/test_models.py:412`** — rename `I = torch.eye(...)` → `eye_n` (E741: linear-algebra `I` clashes with `1`/`l`).
- **`boxcrete/utils.py`** — f-string `{x = }` → `{x=}` (E202/E251); wrap 5 long docstring/error lines.
- **`experiments/check_artifacts_drift.py`** — `*100` → `* 100` (E226).
- **`test/test_lengthscale_identifiability.py`** — `*100` → `* 100` (E226).
- **`boxcrete/concrete_model.py`** — wrap 5 long docstring/error lines.
- **`boxcrete/kernels.py`** — wrap a 196-char inline `pragma: no cover` comment.
- **`boxcrete/likelihoods.py`** — wrap 4 long `pragma: no cover` lines.
- **`boxcrete/slump_model.py`** — wrap 1 long module-docstring line.
- **`test/test_strength_curve_monotonicity.py`** — wrap 3 long error-message lines.
- **`test/test_models.py:220`**, **`test/test_utils.py:679`** — tighten 2 long docstrings.

### Bonus fix in `.flake8`

The explicit `exclude` list (`build, dist, .eggs`) silently overrode flake8's defaults, so `.git`, `__pycache__`, `.hg`, etc. were being linted. Sapling stores backup copies of working-tree files under `.git/sl/origbackups/` — without explicit re-add of the default excludes, flake8 reported 26 phantom violations from old deleted research code. Defaults restored explicitly.

### Developer ergonomics

- **`.pre-commit-config.yaml`** synced to match CI's strict-select. "Green locally" now implies "green CI" — no more surprises after pushing.
- **`README.md`** new `## Development` section explaining one-time setup:

  ```bash
  pip install -e ".[dev]"
  pre-commit install
