### PR TITLE
Optimize concrete explorer canvas scheduling

### DIFF
--- a/docs/ui.mjs
+++ b/docs/ui.mjs
@@ -85,15 +85,17 @@ let currentComposition = null; // current slider values (without time)
 let scatterDay = 28;
 let scatterXAxis = "gwp"; // "gwp" or "cost"
 let curveObsPositions = []; // [{px, py, time, strength}] for tooltip hit-testing
-let animationId = null; // for smooth transitions
-// Most recent animation TARGET (intended end state). When the user commits a
-// click-to-edit value during an in-flight animation, we build the new target
-// from this — not from mid-lerp `currentComposition` — so other still-animating
-// sliders land at their intended positions.
-let _lastAnimTarget = null;
+// Unified-loop-owned composition transition. The target is also the intended
+// end state used by click-to-edit while the interpolation is in flight.
+let compositionTransition = null; // {startComp, targetComp, startTime, duration}
 let scatterFilter = null; // [{colIdx, min, max}] array or null
 let mixAnalyses = null; // pre-computed mix descriptions
+const CANVAS_CURVE = 1;
+const CANVAS_SCATTER = 2;
+const CANVAS_BOTH = CANVAS_CURVE | CANVAS_SCATTER;
+let pendingCanvasMask = 0;
 let animLoopId = null; // unified animation loop frame ID
+let lastAnimFrameTimestamp = null; // coalesces callbacks delivered for one browser frame
 let lastFrameTime = 0; // for frame-rate-independent interpolation
 let scatterTransition = null; // {startTime, duration, fromX, fromY, toX, toY, fromPareto, toPareto}
 let _curveYMax = null; // smoothly interpolated y-axis max for strength curve
@@ -555,7 +557,7 @@ function buildSliders() {
       previewScopeBtn = null;
       previewScopeIdx = i;
       previewScopeValue = value;
-      startAnimLoop();
+      invalidateCanvases(CANVAS_CURVE);
     });
     input.addEventListener("pointerdown", (e) => {
       if (e.pointerType !== "mouse" || previewSource !== "slider") return;
@@ -565,7 +567,7 @@ function buildSliders() {
       for (let j = 0; j < currentComposition.length; j++) {
         displayPreviewComp[j] = currentComposition[j];
       }
-      startAnimLoop();
+      invalidateCanvases(CANVAS_CURVE);
     });
     input.addEventListener("pointerup", disarmSliderCommitPreview);
     input.addEventListener("pointercancel", disarmSliderCommitPreview);
@@ -573,7 +575,7 @@ function buildSliders() {
     input.addEventListener("pointerleave", () => {
       if (previewSource !== "slider") return;
       previewSource = null;
-      if (!restoreFocusedClassPreview()) startAnimLoop();
+      if (!restoreFocusedClassPreview()) invalidateCanvases(CANVAS_CURVE);
     });
 
     const infoRow = document.createElement("div");
@@ -834,38 +836,15 @@ function queueSliderCurveRetarget(
   });
 }
 
-// Coalesce slider redraws to at most one per animation frame.
-//
-// `input` events from a touch drag or a high-polling mouse arrive faster than
-// 60 Hz, and each one used to trigger a full synchronous redraw. A redraw is
-// ~24 ms on a 4x-throttled CPU (98% of it the strength-curve GP evaluation),
-// so bursts queued work the screen could never show.
-//
-// Note this bounds the *burst*, not the total: `onSliderChange` also calls
-// startAnimLoop(), and animLoop unconditionally redraws both canvases, so a
-// drag frame still does this work twice. That overlap predates this change
-// (the old synchronous path had it too, and worse), and removing it means
-// untangling who owns the drag redraw -- deliberately out of scope here.
+// Coalesce high-frequency slider DOM work to at most once per animation
+// frame. Canvas work is owned exclusively by animLoop via dirty bits.
 let _pendingRedraw = null;
 function requestRedraw() {
   if (_pendingRedraw !== null) return;
   _pendingRedraw = requestAnimationFrame(() => {
     _pendingRedraw = null;
-    // When the animation loop is running it already redraws both canvases
-    // every frame, so calling update() here draws them a second time.
-    // Measured during a sustained drag: 1.68 canvas redraws per animation
-    // frame, i.e. ~40% of the work on the one hot path that none of the
-    // earlier optimisations touched.
-    //
-    // The loop only owns the CANVASES, so the rest of update() still has to
-    // run -- dropping it would freeze the readouts and the screen-reader
-    // summary mid-drag.
-    if (animLoopId !== null) {
-      updateReadouts();
-      scheduleCurveSummary();
-    } else {
-      update();
-    }
+    updateReadouts();
+    scheduleCurveSummary();
     updateMixInsight();
     checkExtrapolationWarning();
   });
@@ -910,9 +889,14 @@ function onSliderChange(e) {
   setValueDisplay(idx, displayVal.toFixed(1));
   _sliderActive = true;
   if (_sliderIdleTimer) clearTimeout(_sliderIdleTimer);
-  _sliderIdleTimer = setTimeout(() => { _sliderActive = false; update(); }, 150);
+  _sliderIdleTimer = setTimeout(() => {
+    _sliderActive = false;
+    updateReadouts();
+    scheduleCurveSummary();
+    invalidateCanvases(CANVAS_CURVE);
+  }, 150);
   requestRedraw();
-  startAnimLoop(); // keep loop alive for smooth y-axis expansion
+  invalidateCanvases(CANVAS_BOTH); // curve plus one current-composition marker redraw
 }
 
 // Display value for a composition column under the active unit system.
@@ -983,20 +967,13 @@ function updateSliderLabels() {
 
 // --- Animated transition to a new composition ---
 function cancelCompositionAnimation() {
-  if (animationId !== null) cancelAnimationFrame(animationId);
-  animationId = null;
-  _lastAnimTarget = null;
+  compositionTransition = null;
 }
 
 function animateToComposition(targetComp) {
   cancelCompositionAnimation();
   cancelQueuedSliderCurveRetarget();
   hideExtrapolationWarning(); // suppress during transition
-  startAnimLoop();
-
-  // Track the *intended* end state so a click-to-edit during this animation
-  // can build the new target from un-clobbered values. Cleared on completion.
-  _lastAnimTarget = [...targetComp];
 
   const startComp = [...currentComposition];
 
@@ -1013,43 +990,46 @@ function animateToComposition(targetComp) {
   const msIdx = COL_MS;
   if (msIdx >= 0) startComp[msIdx] = Math.round(targetComp[msIdx]);
 
-  const duration = motionDuration(CURVE_TRANSITION_MS);
-  const startTime = performance.now();
-
-  function step(now) {
-    const t = Math.min((now - startTime) / duration, 1);
-    // Smooth easing (ease-in-out: starts at zero velocity, ends at zero velocity)
-    const ease = easeInOutCubic(t);
-
-    // Lerp each dimension
-    for (let i = 0; i < startComp.length; i++) {
-      currentComposition[i] = startComp[i] + (targetComp[i] - startComp[i]) * ease;
-      if (previewSource === null) displayPreviewComp[i] = currentComposition[i];
-    }
-
-    syncSliderDOM(currentComposition);
-
-    update();
-
-    if (t < 1) {
-      animationId = requestAnimationFrame(step);
-    } else {
-      animationId = null;
-      _lastAnimTarget = null;
-      // Snap to exact target and update toggle
-      setComposition(targetComp);
-      if (_pendingFocusedPreviewRestore) {
-        _pendingFocusedPreviewRestore = false;
-        restoreFocusedClassPreview();
-      }
-      // Sequenced: update insight after the curve has settled
-      scheduleInsightUpdate();
-      checkExtrapolationWarning();
-    }
-  }
-
-  animationId = requestAnimationFrame(step);
+  compositionTransition = {
+    startComp,
+    targetComp: [...targetComp],
+    startTime: performance.now(),
+    duration: motionDuration(CURVE_TRANSITION_MS),
+  };
+  startAnimLoop();
   return curveTransitionId;
+}
+
+function advanceCompositionTransition(now) {
+  const transition = compositionTransition;
+  if (transition === null) return;
+
+  const t = Math.min(
+    (now - transition.startTime) / transition.duration,
+    1,
+  );
+  const ease = easeInOutCubic(t);
+
+  for (let i = 0; i < transition.startComp.length; i++) {
+    currentComposition[i] = transition.startComp[i] +
+      (transition.targetComp[i] - transition.startComp[i]) * ease;
+    if (previewSource === null) displayPreviewComp[i] = currentComposition[i];
+  }
+  syncSliderDOM(currentComposition);
+  update();
+
+  if (t < 1) return;
+
+  compositionTransition = null;
+  // Snap to the exact endpoint and update the Material Source toggle.
+  setComposition(transition.targetComp);
+  if (_pendingFocusedPreviewRestore) {
+    _pendingFocusedPreviewRestore = false;
+    restoreFocusedClassPreview();
+  }
+  // Sequenced: update insight after the curve has settled.
+  scheduleInsightUpdate();
+  checkExtrapolationWarning();
 }
 
 // --- Curve-level transition ---
@@ -1110,7 +1090,7 @@ function clearPreviewHold(restoreFocused = false) {
   const shouldRestore = restoreFocused && _restoreFocusedAfterPreviewHold;
   _restoreFocusedAfterPreviewHold = false;
   if (shouldRestore) {
-    if (animationId !== null) {
+    if (compositionTransition !== null) {
       _pendingFocusedPreviewRestore = true;
     } else {
       restoreFocusedClassPreview();
@@ -1181,7 +1161,7 @@ function beginCurveTransition(targetComp, fromComp = currentComposition) {
 // Material Source toggle: commit the new class immediately (the GP only ever
 // sees an integer class) and crossfade the curve to it.
 function triggerMaterialSourceTransition(idx, newVal) {
-  const interruptedCompositionAnimation = animationId !== null;
+  const interruptedCompositionAnimation = compositionTransition !== null;
   cancelCompositionAnimation();
   cancelQueuedSliderCurveRetarget();
   if (currentComposition[idx] === newVal) {
@@ -1219,8 +1199,8 @@ function attachValueEditHandlers(inputEl, idx, col, b) {
     const clamped = Math.max(b.min, Math.min(b.max, internal));
     // Build target from the most recent intended end state to avoid landing
     // mid-animation values for sliders that are currently in flight.
-    const base = animationId !== null && _lastAnimTarget !== null
-      ? [..._lastAnimTarget]
+    const base = compositionTransition !== null
+      ? [...compositionTransition.targetComp]
       : [...currentComposition];
     base[idx] = clamped;
     animateToComposition(base);
@@ -1304,7 +1284,7 @@ function updateCurveSummary() {
   // which would leave the summary permanently stale (e.g. after a unit
   // toggle, whose animation is in flight when the debounce first fires).
   if (
-    animationId !== null ||
+    compositionTransition !== null ||
     _sliderActive ||
     _curveTransition !== null ||
     unitTransition !== null
@@ -1347,9 +1327,8 @@ function updateCurveSummary() {
 
 function update() {
   updateReadouts();
-  drawStrengthCurve();
-  drawScatter();
   scheduleCurveSummary();
+  invalidateCanvases(CANVAS_BOTH);
   // Mix insight updates are triggered separately with delay (see animateToComposition)
 }
 
@@ -1488,20 +1467,16 @@ function setupHiDPICanvas(canvas) {
     rect = canvas.getBoundingClientRect();
     _canvasCache.set(canvas, { width: rect.width, height: rect.height });
     rect = _canvasCache.get(canvas);
-    // Observe resize to invalidate cache and trigger redraw
+    // Observe resize to invalidate cache and redraw only affected canvases.
     if (!_resizeObserver) {
-      let resizeRAF = null;
       _resizeObserver = new ResizeObserver((entries) => {
+        let mask = 0;
         for (const entry of entries) {
           _canvasCache.delete(entry.target);
+          if (entry.target.id === "curve-canvas") mask |= CANVAS_CURVE;
+          if (entry.target.id === "scatter-canvas") mask |= CANVAS_SCATTER;
         }
-        // Debounce redraw to next animation frame for snappy resize
-        if (!resizeRAF) {
-          resizeRAF = requestAnimationFrame(() => {
-            resizeRAF = null;
-            update();
-          });
-        }
+        if (mask !== 0) invalidateCanvases(mask);
       });
     }
     _resizeObserver.observe(canvas);
@@ -1688,7 +1663,7 @@ function drawStrengthCurve() {
     }
   }
   if (means === undefined) {
-    const isAnimating = animationId !== null;
+    const isAnimating = compositionTransition !== null;
     const isInteracting = _sliderActive || isAnimating || showPreview;
     nPts = isInteracting ? 32 : 64;
     times = logSpacedTimes(nPts);
@@ -2420,13 +2395,36 @@ function isCompositionConverged() {
 }
 
 // --- Unified Animation Loop ---
+function invalidateCanvases(mask) {
+  pendingCanvasMask |= mask;
+  startAnimLoop();
+}
+
+function scheduleAnimLoopFrame() {
+  const frameId = requestAnimationFrame((now) => {
+    // A cancelled callback can already be queued for delivery. Ignore it if a
+    // newer callback owns the loop, otherwise both would render in one frame.
+    if (animLoopId !== frameId) return;
+    if (now === lastAnimFrameTimestamp) {
+      animLoopId = null;
+      scheduleAnimLoopFrame();
+      return;
+    }
+    lastAnimFrameTimestamp = now;
+    animLoop(now);
+  });
+  animLoopId = frameId;
+}
+
 function startAnimLoop() {
-  if (animLoopId) return;
+  if (animLoopId !== null) return;
   lastFrameTime = performance.now();
-  animLoopId = requestAnimationFrame(animLoop);
+  scheduleAnimLoopFrame();
 }
 
 function animLoop(now) {
+  advanceCompositionTransition(now);
+
   const dt = now - lastFrameTime;
   lastFrameTime = now;
 
@@ -2516,20 +2514,51 @@ function animLoop(now) {
     _firstAnimFrameDone = true;
   }
 
-  // Redraw. A disappearing preview gets one additional frame so the solid
-  // curve immediately returns from the 32-point interaction grid to 64 points.
-  drawScatter();
-  const idleRedrawWasPending = _previewIdleRedrawPending;
-  drawStrengthCurve();
-  if (idleRedrawWasPending) _previewIdleRedrawPending = false;
-
-  // Continue or stop (no wasted work when idle)
   const hasHoverAnim = (Math.abs(hoverScale - hoverScaleTarget) > 0.01) || prevHoveredPointIdx !== null;
   const hasCurveAnim = Math.abs(curveObsHoverScale - curveHoverTarget) > 0.01;
   const hasObsAnim = Math.abs(obsOpacity - obsTarget) > 0.01;
   const hasYAxisAnim = _curveYMaxTarget !== null && Math.abs(_curveYMax - _curveYMaxTarget) > 0.5;
-  if (!previewConverged || hasHoverAnim || hasCurveAnim || hasObsAnim || hasYAxisAnim || animationId !== null || scatterTransition !== null || unitTransition !== null || _curveTransition !== null || _previewCurveTransition !== null || _previewIdleRedrawPending) {
-    animLoopId = requestAnimationFrame(animLoop);
+
+  // Snapshot and clear pending work before drawing. A renderer may request a
+  // cleanup frame while completing a transition, and that request must survive.
+  let frameMask = pendingCanvasMask;
+  pendingCanvasMask = 0;
+  if (
+    !previewConverged || hasCurveAnim || hasObsAnim || hasYAxisAnim ||
+    _curveTransition !== null || _previewCurveTransition !== null ||
+    _previewIdleRedrawPending
+  ) {
+    frameMask |= CANVAS_CURVE;
+  }
+  if (hasHoverAnim || scatterTransition !== null) frameMask |= CANVAS_SCATTER;
+  if (
+    previewSource === "scatter" ||
+    compositionTransition !== null ||
+    unitTransition !== null
+  ) {
+    frameMask |= CANVAS_BOTH;
+  }
+
+  if (frameMask & CANVAS_SCATTER) drawScatter();
+  if (frameMask & CANVAS_CURVE) {
+    const idleRedrawWasPending = _previewIdleRedrawPending;
+    drawStrengthCurve();
+    if (idleRedrawWasPending) _previewIdleRedrawPending = false;
+  }
+
+  // Renderers own transition completion and can establish new convergence
+  // work, so continuation must be evaluated against their post-draw state.
+  const yAxisStillAnimating =
+    _curveYMaxTarget !== null && Math.abs(_curveYMax - _curveYMaxTarget) > 0.5;
+  if (
+    !previewConverged || hasHoverAnim || hasCurveAnim || hasObsAnim ||
+    yAxisStillAnimating || compositionTransition !== null || scatterTransition !== null ||
+    unitTransition !== null || _curveTransition !== null ||
+    _previewCurveTransition !== null || _previewIdleRedrawPending ||
+    pendingCanvasMask !== 0
+  ) {
+    animLoopId = null;
+    scheduleAnimLoopFrame();
   } else {
     animLoopId = null;
   }
@@ -2598,7 +2627,7 @@ function setupEventListeners() {
         previewSource = null;
         restoreFocusedClassPreview();
       }
-      startAnimLoop();
+      invalidateCanvases(CANVAS_BOTH);
     }
   });
 
@@ -2612,9 +2641,9 @@ function setupEventListeners() {
       hoverScaleTarget = 0;
       if (previewSource === "scatter") {
         previewSource = null;
-        if (!restoreFocusedClassPreview()) startAnimLoop();
+        if (!restoreFocusedClassPreview()) invalidateCanvases(CANVAS_BOTH);
       } else {
-        startAnimLoop();
+        invalidateCanvases(CANVAS_BOTH);
       }
       scatterCanvas.style.cursor = "default";
     }
@@ -2847,7 +2876,7 @@ function setupEventListeners() {
         }
       }
     }
-    drawScatter();
+    invalidateCanvases(CANVAS_SCATTER);
   }
 
   document.getElementById("filter-add").addEventListener("click", () => {
@@ -2872,7 +2901,7 @@ function setupEventListeners() {
         finished++;
         if (finished === wrappers.length) {
           scatterFilter = null;
-          drawScatter();
+          invalidateCanvases(CANVAS_SCATTER);
         }
       };
     }
@@ -2907,7 +2936,7 @@ function setupEventListeners() {
     if (hitIdx !== hoveredCurveObsIdx) {
       hoveredCurveObsIdx = hitIdx;
       curveObsHoverScale = 0;
-      startAnimLoop();
+      invalidateCanvases(CANVAS_CURVE);
     }
 
     if (hit) {
@@ -2929,7 +2958,7 @@ function setupEventListeners() {
     curveCanvas.style.cursor = "default";
     if (hoveredCurveObsIdx !== null) {
       hoveredCurveObsIdx = null;
-      startAnimLoop();
+      invalidateCanvases(CANVAS_CURVE);
     }
   });
 }
@@ -2961,7 +2990,7 @@ new MutationObserver(() => { _canvasColors = null; update(); }).observe(
 document.addEventListener("invalidate-scatter", () => {
   const canvas = document.getElementById("scatter-canvas");
   _canvasCache.delete(canvas);
-  update();
+  invalidateCanvases(CANVAS_SCATTER);
 });
 
 // --- Test hook (gated behind ?test=1 to avoid leaking internals in prod) ---
@@ -3012,9 +3041,13 @@ if (typeof location !== "undefined" &&
     get isPreviewVisualHeld() {
       return _previewHoldCurveTransitionId !== null;
     },
-    get isCompositionTransitionActive() { return animationId !== null; },
+    get isCompositionTransitionActive() {
+      return compositionTransition !== null;
+    },
     get compositionTransitionTarget() {
-      return _lastAnimTarget ? [..._lastAnimTarget] : null;
+      return compositionTransition
+        ? [...compositionTransition.targetComp]
+        : null;
     },
     get isAnimLoopActive() { return animLoopId !== null; },
     // The UI shell now renders before the strength GP finishes building (it is

--- a/test/e2e/canvas-frame-probe.ts
+++ b/test/e2e/canvas-frame-probe.ts
@@ -1,0 +1,204 @@
+import { expect, type Page } from "@playwright/test";
+
+export type CanvasName = "curve" | "scatter";
+
+export type CanvasDrawEvent = {
+  canvas: CanvasName;
+  frameTime: number | null;
+  phase: "raf" | "sync";
+};
+
+export type CanvasFrame = {
+  frameTime: number | null;
+  curve: number;
+  scatter: number;
+};
+
+export type CanvasFrameSnapshot = {
+  events: CanvasDrawEvent[];
+  frames: CanvasFrame[];
+};
+
+declare global {
+  interface Window {
+    __test?: any;
+    __canvasFrameProbe?: {
+      reset(): void;
+      snapshot(): CanvasDrawEvent[];
+    };
+  }
+}
+
+export async function installCanvasFrameProbe(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    if (window.__canvasFrameProbe) return;
+
+    const nativeRequestAnimationFrame = window.requestAnimationFrame.bind(window);
+    const widthDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLCanvasElement.prototype,
+      "width",
+    );
+    if (!widthDescriptor?.get || !widthDescriptor.set) {
+      throw new Error("HTMLCanvasElement.width accessors are unavailable");
+    }
+
+    let events: CanvasDrawEvent[] = [];
+    let activeFrameTime: number | null = null;
+    let rafDepth = 0;
+
+    window.requestAnimationFrame = (callback: FrameRequestCallback): number =>
+      nativeRequestAnimationFrame((frameTime) => {
+        const previousFrameTime = activeFrameTime;
+        activeFrameTime = frameTime;
+        rafDepth += 1;
+        try {
+          callback(frameTime);
+        } finally {
+          rafDepth -= 1;
+          activeFrameTime = previousFrameTime;
+        }
+      });
+
+    Object.defineProperty(HTMLCanvasElement.prototype, "width", {
+      ...widthDescriptor,
+      set(this: HTMLCanvasElement, value: number) {
+        widthDescriptor.set!.call(this, value);
+        const canvas = this.id === "curve-canvas"
+          ? "curve"
+          : this.id === "scatter-canvas"
+            ? "scatter"
+            : null;
+        if (canvas === null) return;
+        events.push({
+          canvas,
+          frameTime: rafDepth > 0 ? activeFrameTime : null,
+          phase: rafDepth > 0 ? "raf" : "sync",
+        });
+      },
+    });
+
+    window.__canvasFrameProbe = {
+      reset() {
+        events = [];
+      },
+      snapshot() {
+        return events.map((event) => ({ ...event }));
+      },
+    };
+  });
+}
+
+export async function waitForCanvasAppReady(page: Page): Promise<void> {
+  await page.goto("/?test=1");
+  await page.waitForFunction(
+    () => window.__test?.modelReady === true,
+    null,
+    { timeout: 30_000 },
+  );
+  await page.locator("#sliders input[type=range]").first().waitFor({ state: "attached" });
+  await waitForCanvasLoopToPark(page);
+}
+
+export async function waitForCanvasLoopToPark(page: Page): Promise<void> {
+  await expect
+    .poll(
+      () => page.evaluate(() => {
+        const testState = window.__test;
+        return Boolean(
+          testState &&
+            !testState.isAnimLoopActive &&
+            !testState.isCurveTransitionActive &&
+            !testState.isPreviewCurveTransitionActive &&
+            !testState.isCompositionTransitionActive,
+        );
+      }),
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+
+  await page.evaluate(() =>
+    new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    ),
+  );
+
+  await expect
+    .poll(() => page.evaluate(() => !window.__test?.isAnimLoopActive))
+    .toBe(true);
+}
+
+export async function resetCanvasFrameProbe(page: Page): Promise<void> {
+  await page.evaluate(() => window.__canvasFrameProbe?.reset());
+}
+
+export async function snapshotCanvasFrames(page: Page): Promise<CanvasFrameSnapshot> {
+  const events = await page.evaluate(() => window.__canvasFrameProbe?.snapshot() ?? []);
+  const byFrame = new Map<number, CanvasFrame>();
+  for (const event of events) {
+    if (event.phase !== "raf" || event.frameTime === null) continue;
+    let frame = byFrame.get(event.frameTime);
+    if (!frame) {
+      frame = { frameTime: event.frameTime, curve: 0, scatter: 0 };
+      byFrame.set(event.frameTime, frame);
+    }
+    frame[event.canvas] += 1;
+  }
+  return { events, frames: [...byFrame.values()] };
+}
+
+export function drawCount(snapshot: CanvasFrameSnapshot, canvas: CanvasName): number {
+  return snapshot.events.filter((event) => event.canvas === canvas).length;
+}
+
+export function maxDrawsPerFrame(
+  snapshot: CanvasFrameSnapshot,
+  canvas: CanvasName,
+): number {
+  return Math.max(0, ...snapshot.frames.map((frame) => frame[canvas]));
+}
+
+export function expectAtMostOneDrawPerCanvasPerFrame(
+  snapshot: CanvasFrameSnapshot,
+): void {
+  expect(snapshot.frames, "expected at least one canvas frame").not.toHaveLength(0);
+  expect(
+    snapshot.events.filter((event) => event.phase === "sync"),
+    "canvas renderers must be owned by requestAnimationFrame",
+  ).toHaveLength(0);
+  expect(
+    maxDrawsPerFrame(snapshot, "curve"),
+    `curve draw counts by frame: ${JSON.stringify(snapshot.frames)}`,
+  ).toBeLessThanOrEqual(1);
+  expect(
+    maxDrawsPerFrame(snapshot, "scatter"),
+    `scatter draw counts by frame: ${JSON.stringify(snapshot.frames)}`,
+  ).toBeLessThanOrEqual(1);
+}
+
+export async function hoverRenderedScatterPoint(page: Page): Promise<void> {
+  const canvas = page.locator("#scatter-canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("scatter canvas has no bounding box");
+
+  for (let y = 30; y < box.height - 30; y += 8) {
+    for (let x = 75; x < box.width - 20; x += 8) {
+      await page.mouse.move(box.x + x, box.y + y);
+      if (await page.evaluate(() => window.__test?.hoveredPointIdx !== null)) return;
+    }
+  }
+  throw new Error("could not locate a rendered scatter point");
+}
+
+export async function hoverRenderedCurveObservation(page: Page): Promise<void> {
+  const canvas = page.locator("#curve-canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("curve canvas has no bounding box");
+
+  for (let y = 20; y < box.height - 20; y += 5) {
+    for (let x = 50; x < box.width - 20; x += 5) {
+      await page.mouse.move(box.x + x, box.y + y);
+      if (await page.locator(".tooltip").isVisible()) return;
+    }
+  }
+  throw new Error("could not locate a rendered curve observation");
+}

--- a/test/e2e/canvas-scheduling.spec.ts
+++ b/test/e2e/canvas-scheduling.spec.ts
@@ -1,0 +1,248 @@
+import { expect, test } from "@playwright/test";
+import {
+  drawCount,
+  expectAtMostOneDrawPerCanvasPerFrame,
+  hoverRenderedCurveObservation,
+  hoverRenderedScatterPoint,
+  installCanvasFrameProbe,
+  resetCanvasFrameProbe,
+  snapshotCanvasFrames,
+  waitForCanvasAppReady,
+  waitForCanvasLoopToPark,
+} from "./canvas-frame-probe";
+
+test.beforeEach(async ({ page }) => {
+  await installCanvasFrameProbe(page);
+});
+
+async function expectCurveOnly(page: import("@playwright/test").Page) {
+  const snapshot = await snapshotCanvasFrames(page);
+  expect(drawCount(snapshot, "curve"), "expected curve redraws").toBeGreaterThan(0);
+  expect(drawCount(snapshot, "scatter"), JSON.stringify(snapshot.frames)).toBe(0);
+  expectAtMostOneDrawPerCanvasPerFrame(snapshot);
+}
+
+async function expectScatterOnly(page: import("@playwright/test").Page) {
+  const snapshot = await snapshotCanvasFrames(page);
+  expect(drawCount(snapshot, "scatter"), "expected scatter redraws").toBeGreaterThan(0);
+  expect(drawCount(snapshot, "curve"), JSON.stringify(snapshot.frames)).toBe(0);
+  expectAtMostOneDrawPerCanvasPerFrame(snapshot);
+}
+
+test.describe("canvas scheduling", () => {
+  test("scatter composition animation draws each canvas at most once per frame", async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop interaction");
+    await waitForCanvasAppReady(page);
+    await hoverRenderedScatterPoint(page);
+    await resetCanvasFrameProbe(page);
+
+    await page.locator("#scatter-canvas").click();
+    await expect
+      .poll(() => page.evaluate(() => window.__test?.isCompositionTransitionActive))
+      .toBe(true);
+    await waitForCanvasLoopToPark(page);
+
+    const snapshot = await snapshotCanvasFrames(page);
+    expect(drawCount(snapshot, "curve")).toBeGreaterThan(0);
+    expect(drawCount(snapshot, "scatter")).toBeGreaterThan(0);
+    expectAtMostOneDrawPerCanvasPerFrame(snapshot);
+  });
+
+  test("slider preview and return redraw only the curve", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover interaction");
+    await waitForCanvasAppReady(page);
+    const slider = page.locator("#sliders input[type=range]").nth(1);
+    const box = await slider.boundingBox();
+    if (!box) throw new Error("slider has no bounding box");
+    await resetCanvasFrameProbe(page);
+
+    await page.mouse.move(box.x + box.width * 0.75, box.y + box.height / 2);
+    await expect.poll(() => page.evaluate(() => window.__test?.previewSource)).toBe("slider");
+    await expect.poll(() => page.evaluate(() => {
+      const t = window.__test;
+      return t.displayPreviewComp.some(
+        (value: number, idx: number) => Math.abs(value - t.currentComposition[idx]) > 1e-6,
+      );
+    })).toBe(true);
+    await waitForCanvasLoopToPark(page);
+    await expectCurveOnly(page);
+
+    await resetCanvasFrameProbe(page);
+    await page.mouse.move(0, 0);
+    await waitForCanvasLoopToPark(page);
+    await expectCurveOnly(page);
+  });
+
+  test("Material Source hover and focus preview redraw only the curve", async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover interaction");
+    await waitForCanvasAppReady(page);
+    const inactive = page.locator(".material-source-group .toggle-btn:not(.active)").first();
+    await resetCanvasFrameProbe(page);
+
+    await inactive.hover();
+    await inactive.focus();
+    await expect.poll(() => page.evaluate(() => window.__test?.previewSource)).toBe("class");
+    await waitForCanvasLoopToPark(page);
+    await expectCurveOnly(page);
+
+    await resetCanvasFrameProbe(page);
+    await inactive.blur();
+    await page.mouse.move(0, 0);
+    await waitForCanvasLoopToPark(page);
+    await expectCurveOnly(page);
+  });
+
+  test("direct slider commit redraws scatter only at the boundary", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop interaction");
+    await waitForCanvasAppReady(page);
+    const slider = page.locator("#sliders input[type=range]").first();
+    await resetCanvasFrameProbe(page);
+
+    await slider.focus();
+    await page.keyboard.press("ArrowRight");
+    await expect
+      .poll(() => page.evaluate(() => window.__test?.isCurveTransitionActive))
+      .toBe(true);
+    await waitForCanvasLoopToPark(page);
+
+    const snapshot = await snapshotCanvasFrames(page);
+    expect(drawCount(snapshot, "scatter"), JSON.stringify(snapshot.frames)).toBe(1);
+    expect(drawCount(snapshot, "curve")).toBeGreaterThan(1);
+    expectAtMostOneDrawPerCanvasPerFrame(snapshot);
+  });
+
+  test("direct Material Source commit redraws scatter only at the boundary", async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop interaction");
+    await waitForCanvasAppReady(page);
+    const inactive = page.locator(".material-source-group .toggle-btn:not(.active)").first();
+    await resetCanvasFrameProbe(page);
+
+    await inactive.click();
+    await expect
+      .poll(() => page.evaluate(() => window.__test?.isCurveTransitionActive))
+      .toBe(true);
+    await waitForCanvasLoopToPark(page);
+
+    const snapshot = await snapshotCanvasFrames(page);
+    expect(drawCount(snapshot, "scatter"), JSON.stringify(snapshot.frames)).toBe(1);
+    expect(drawCount(snapshot, "curve")).toBeGreaterThan(1);
+    expectAtMostOneDrawPerCanvasPerFrame(snapshot);
+  });
+
+  for (const selector of ["#toggle-x", "#toggle-day"]) {
+    test(`${selector} transition redraws only scatter`, async ({ page }, testInfo) => {
+      test.skip(testInfo.project.name !== "desktop", "desktop scatter controls");
+      await waitForCanvasAppReady(page);
+      await resetCanvasFrameProbe(page);
+
+      await page.locator(selector).click();
+      await expect.poll(() => page.evaluate(() => window.__test?.isAnimLoopActive)).toBe(true);
+      await waitForCanvasLoopToPark(page);
+
+      await expectScatterOnly(page);
+    });
+  }
+
+  test("curve observation hover redraws only the curve", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover interaction");
+    await waitForCanvasAppReady(page);
+    await resetCanvasFrameProbe(page);
+
+    await hoverRenderedCurveObservation(page);
+    await page.mouse.move(0, 0);
+    await waitForCanvasLoopToPark(page);
+
+    await expectCurveOnly(page);
+  });
+
+  test("scatter hover redraws both canvases at most once per frame", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover interaction");
+    await waitForCanvasAppReady(page);
+    await resetCanvasFrameProbe(page);
+
+    await hoverRenderedScatterPoint(page);
+    await page.mouse.move(0, 0);
+    await waitForCanvasLoopToPark(page);
+
+    const snapshot = await snapshotCanvasFrames(page);
+    expect(drawCount(snapshot, "curve")).toBeGreaterThan(0);
+    expect(drawCount(snapshot, "scatter")).toBeGreaterThan(0);
+    expectAtMostOneDrawPerCanvasPerFrame(snapshot);
+  });
+
+  test("theme and unit changes redraw both canvases", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop controls");
+    await waitForCanvasAppReady(page);
+
+    for (const selector of ["#theme-toggle", "#unit-toggle"]) {
+      await resetCanvasFrameProbe(page);
+      await page.locator(selector).click();
+      await expect
+        .poll(async () => {
+          const snapshot = await snapshotCanvasFrames(page);
+          return drawCount(snapshot, "curve") > 0 && drawCount(snapshot, "scatter") > 0;
+        })
+        .toBe(true);
+      await waitForCanvasLoopToPark(page);
+      expectAtMostOneDrawPerCanvasPerFrame(await snapshotCanvasFrames(page));
+    }
+  });
+
+  test("resizing one canvas redraws only that canvas", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop layout");
+    await waitForCanvasAppReady(page);
+
+    for (const canvas of ["curve", "scatter"] as const) {
+      const selector = `#${canvas}-canvas`;
+      await resetCanvasFrameProbe(page);
+      await page.locator(selector).evaluate((element) => {
+        (element as HTMLElement).style.width = "calc(100% - 1px)";
+      });
+      await expect
+        .poll(async () => drawCount(await snapshotCanvasFrames(page), canvas))
+        .toBeGreaterThan(0);
+      await waitForCanvasLoopToPark(page);
+      const snapshot = await snapshotCanvasFrames(page);
+      const other = canvas === "curve" ? "scatter" : "curve";
+      expect(drawCount(snapshot, other), JSON.stringify(snapshot.frames)).toBe(0);
+    }
+  });
+
+  test("filters redraw only scatter", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop filter controls");
+    await waitForCanvasAppReady(page);
+    await page.locator("#filter-add").click();
+    await resetCanvasFrameProbe(page);
+
+    const minimum = page.locator(".filter-min").first();
+    await minimum.fill("1");
+    await minimum.dispatchEvent("change");
+    await expect
+      .poll(async () => drawCount(await snapshotCanvasFrames(page), "scatter"))
+      .toBeGreaterThan(0);
+
+    await expectScatterOnly(page);
+  });
+
+  test("mobile scatter reveal invalidates only scatter", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "mobile", "mobile-only");
+    await waitForCanvasAppReady(page);
+    await page.locator("#mobile-show-sliders").click();
+    await expect(page.locator(".mobile-sliders-view")).toBeVisible();
+    await resetCanvasFrameProbe(page);
+
+    await page.locator("#mobile-show-scatter").click();
+    await expect(page.locator(".scatter-content")).toBeVisible();
+    await expect
+      .poll(async () => drawCount(await snapshotCanvasFrames(page), "scatter"))
+      .toBeGreaterThan(0);
+
+    await expectScatterOnly(page);
+  });
+});

--- a/test/e2e/drag-redraw.spec.ts
+++ b/test/e2e/drag-redraw.spec.ts
@@ -1,77 +1,56 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import {
+  drawCount,
+  expectAtMostOneDrawPerCanvasPerFrame,
+  installCanvasFrameProbe,
+  resetCanvasFrameProbe,
+  snapshotCanvasFrames,
+  waitForCanvasAppReady,
+  waitForCanvasLoopToPark,
+} from "./canvas-frame-probe";
 
 /**
  * Drag redraw efficiency.
  *
- * `onSliderChange` schedules a coalesced redraw AND keeps the animation loop
- * alive. The loop already redraws both canvases every frame, so update() from
- * the coalesced callback drew them a second time — measured at 1.68 canvas
- * redraws per animation frame during a sustained drag, i.e. ~40% wasted work
- * on the one interaction path that the earlier transition/worker optimisations
- * never touched.
- *
- * The loop owns the canvases while it runs; the coalesced callback still has
- * to do the non-canvas work, so this also pins that the readouts keep updating.
+ * Slider input can arrive faster than display refresh. The application must
+ * coalesce that work so each canvas renders at most once per browser frame,
+ * while keeping synchronous readouts current throughout the gesture.
  */
-test("drag does not redraw the canvases twice per frame", async ({ page }, testInfo) => {
+test("drag redraws each canvas at most once per frame", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "desktop", "one project is enough");
+  await installCanvasFrameProbe(page);
+  await waitForCanvasAppReady(page);
+  await resetCanvasFrameProbe(page);
 
-  await page.goto("/?test=1");
-  await page.waitForFunction(() => (window as any).__test?.modelReady === true, null, {
-    timeout: 30000,
-  });
-  await page.waitForTimeout(800);
-
-  const r = await page.evaluate(async () => {
-    // setupHiDPICanvas assigns canvas.width on every draw, so counting
-    // assignments counts redraws directly.
-    const counts: Record<string, number> = { curve: 0, scatter: 0 };
-    for (const [key, id] of [
-      ["curve", "curve-canvas"],
-      ["scatter", "scatter-canvas"],
-    ] as const) {
-      const c = document.getElementById(id) as HTMLCanvasElement;
-      let real = c.width;
-      Object.defineProperty(c, "width", {
-        get: () => real,
-        set: (v) => { counts[key]++; real = v; },
-        configurable: true,
-      });
-    }
-
-    let frames = 0;
-    let running = true;
-    const tick = () => { if (running) { frames++; requestAnimationFrame(tick); } };
-    requestAnimationFrame(tick);
-
-    // Drive input faster than 60 Hz, as a touch drag or high-polling mouse does.
-    const s = document.querySelector("#sliders input[type=range]") as HTMLInputElement;
-    const min = parseFloat(s.min);
-    const max = parseFloat(s.max);
-    const t0 = performance.now();
+  const readout = await page.evaluate(async () => {
+    const slider = document.querySelector("#sliders input[type=range]") as HTMLInputElement;
+    const initialReadout = document.getElementById("gwp-value")?.textContent;
+    const seenReadouts = new Set<string | undefined>([initialReadout]);
+    const min = Number(slider.min);
+    const max = Number(slider.max);
+    const deadline = performance.now() + 750;
     let events = 0;
-    while (performance.now() - t0 < 1500) {
-      s.value = String(min + (max - min) * ((events % 20) / 20));
-      s.dispatchEvent(new Event("input", { bubbles: true }));
-      events++;
-      await new Promise((res) => setTimeout(res, 8));
-    }
-    running = false;
-    await new Promise((res) => setTimeout(res, 300));
 
-    return { ...counts, frames, readout: document.getElementById("gwp-value")?.textContent };
+    while (performance.now() < deadline) {
+      slider.value = String(min + (max - min) * ((events % 20) / 20));
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+      seenReadouts.add(document.getElementById("gwp-value")?.textContent);
+      events += 1;
+      await new Promise<void>((resolve) => setTimeout(resolve, 8));
+    }
+
+    return {
+      final: document.getElementById("gwp-value")?.textContent,
+      distinctValues: seenReadouts.size,
+    };
   });
 
-  expect(r.frames, "no animation frames observed").toBeGreaterThan(10);
+  await waitForCanvasLoopToPark(page);
+  const snapshot = await snapshotCanvasFrames(page);
 
-  const perFrame = r.curve / r.frames;
-  expect(
-    perFrame,
-    `${r.curve} curve redraws over ${r.frames} frames = ${perFrame.toFixed(2)}/frame ` +
-      "(was 1.68 when the loop and the coalesced callback both drew)",
-  ).toBeLessThan(1.35);
-
-  // The coalesced callback must still do the non-canvas work.
-  expect(r.readout, "readouts stopped updating during the drag").toBeTruthy();
-  expect(r.readout).not.toBe("–");
+  expect(drawCount(snapshot, "curve"), "expected curve redraws during drag").toBeGreaterThan(10);
+  expectAtMostOneDrawPerCanvasPerFrame(snapshot);
+  expect(readout.final, "readouts stopped updating during the drag").toBeTruthy();
+  expect(readout.final).not.toBe("–");
+  expect(readout.distinctValues, "readout stayed stale throughout the drag").toBeGreaterThan(1);
 });


### PR DESCRIPTION
Make the unified animation loop the sole canvas renderer, add targeted dirty-bit invalidation, and fold composition interpolation into the shared loop.

Add native-forwarding Playwright frame probes and scheduling coverage for per-frame ownership, targeted redraws, mobile reveal, and live drag readouts.