### PR TITLE
[WIP] E2E: deterministic synchronization and CI-aligned Playwright projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-# Local CI-equivalent targets. Mirrors the suite of GitHub Actions
-# workflows in .github/workflows/ so that `make check-all` matches the
-# checks a PR will run on CI.
+# Local test-suite targets. `make check-all` covers the same test suites
+# and Playwright projects as CI, but does not reproduce GitHub runner,
+# artifact, job-topology, or branch-protection behavior.
 #
 #   make help               - list targets
 #
@@ -13,27 +13,28 @@
 #
 # === Slow (minutes) ===
 #   make test-notebooks     - execute every notebook     (notebooks.yml :mode-*)
-#   make test-e2e           - Playwright desktop+mobile  (e2e.yml)
+#   make test-e2e           - fast Playwright Chromium loop (desktop+mobile)
+#   make test-e2e-all       - all four Playwright projects (e2e.yml)
 #   make test-plot-geometry - focused Chromium/WebKit plot contracts
 #   make test-lighthouse    - Lighthouse CI              (lighthouse.yml)
 #
 # === Aggregates ===
 #   make test               - fast tests (py + js + notebook-fmt)
 #   make check              - lint + test          (recommended pre-commit gate)
-#   make check-all          - lint + every test    (full local CI parity)
+#   make check-all          - lint + every local suite/project (pre-merge)
 #
 # Most targets need extras installed:
 #   pip install -e ".[dev]"        # lint, test-py
 #   pip install -e ".[notebooks]"  # test-notebook-fmt, test-notebooks
 #   npm ci                         # test-js, test-e2e, test-lighthouse
-#   npx playwright install --with-deps chromium   # test-e2e
+#   npx playwright install --with-deps chromium webkit  # Playwright targets
 
 PYTHON ?= python
 
 .PHONY: help \
         lint format \
         test-py test-js test-notebook-fmt test-notebooks \
-        test-e2e test-plot-geometry test-lighthouse \
+        test-e2e test-e2e-all test-plot-geometry test-lighthouse \
         test check check-all
 
 help:
@@ -48,14 +49,15 @@ help:
 	@echo ""
 	@echo "  Slow:"
 	@echo "    make test-notebooks     - execute every notebook"
-	@echo "    make test-e2e           - Playwright (desktop + mobile)"
+	@echo "    make test-e2e           - fast Playwright loop (desktop + mobile Chromium)"
+	@echo "    make test-e2e-all       - Playwright (all four Chromium/WebKit projects)"
 	@echo "    make test-plot-geometry - focused plot geometry in Chromium + WebKit"
 	@echo "    make test-lighthouse    - Lighthouse CI"
 	@echo ""
 	@echo "  Aggregates:"
 	@echo "    make test               - fast tests"
 	@echo "    make check              - lint + test (recommended)"
-	@echo "    make check-all          - lint + every test (full CI parity)"
+	@echo "    make check-all          - lint + every local suite/project (pre-merge)"
 
 # Tracked Python files. CI's `black --check --diff .` only sees files
 # in the checked-out commit, so locally we must scope to tracked files
@@ -178,11 +180,18 @@ test-notebooks:
 	done
 
 # --- E2E (Playwright) ----------------------------------------------
-# Mirrors .github/workflows/e2e.yml. Requires `npm ci` + a one-time
-# `npx playwright install --with-deps chromium` to set up browsers.
+# Fast local loop: the broad desktop and mobile Chromium projects.
+# Requires `npm ci` + a one-time browser installation (see header).
 test-e2e:
 	npx playwright test --project=desktop
 	npx playwright test --project=mobile
+
+# Comprehensive local E2E gate: every Playwright project CI executes, once.
+test-e2e-all:
+	npx playwright test --project=desktop
+	npx playwright test --project=mobile
+	npx playwright test --project=mobile-webkit
+	npx playwright test --project=desktop-webkit
 
 test-plot-geometry:
 	npx playwright test test/e2e/plot-geometry.spec.ts test/e2e/scatter-toggle.spec.ts \
@@ -197,4 +206,4 @@ test-lighthouse:
 # --- Aggregates ----------------------------------------------------
 test: test-py test-js test-notebook-fmt
 check: lint test
-check-all: lint test-py test-js test-notebook-fmt test-notebooks test-e2e test-lighthouse
+check-all: lint test-py test-js test-notebook-fmt test-notebooks test-e2e-all test-lighthouse

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -87,7 +87,13 @@ property on a PR, add a spec for it before merging.
 npm install
 npx playwright install --with-deps chromium webkit
 
-# run all tests
+# fast local loop: desktop + mobile Chromium
+make test-e2e
+
+# comprehensive pre-merge loop: all four Chromium/WebKit projects
+make test-e2e-all
+
+# run every configured project in a single Playwright invocation
 npm run test:e2e
 
 # run only mobile Chromium project

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -169,6 +169,13 @@ Visual specs are tagged `@visual`. Verify a regeneration by re-running
 5. Run locally to confirm it passes.
 6. PR it.
 
+## Authoring rules
+
+- Apply custom viewport, media emulation, init scripts, and preload state before the initial navigation.
+- Install canvas init-script probes before navigation.
+- Use the `request` fixture without page navigation for asset-only tests.
+- Synchronize on observable DOM, geometry, animation, focus, or `window.__test` state instead of sleeping for a guessed duration unless timing itself is the contract.
+
 ## Anti-patterns to avoid
 
 - **`page.waitForTimeout` for animation settlement** — replace with `expect.poll()`,

--- a/test/e2e/accessibility.spec.ts
+++ b/test/e2e/accessibility.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "@playwright/test";
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
 /**
  * Accessibility invariants for the explorer.
@@ -18,14 +22,10 @@ import { test, expect } from "@playwright/test";
 // sliders are actually rendered before we inspect them.
 async function openApp(page: import("@playwright/test").Page, project: string) {
   await page.goto("/");
+  await waitForDashboardLayoutReady(page);
   if (project === "mobile") {
-    await page.locator("#mobile-show-sliders").click();
-    await expect(page.locator(".mobile-sliders-view")).toBeVisible({ timeout: 5000 });
+    await openMobileComposition(page);
   }
-  await page
-    .locator("input[type=range]")
-    .first()
-    .waitFor({ state: "visible", timeout: 15000 });
 }
 
 // Strength unit currently quoted by the summary, or undefined.
@@ -234,7 +234,7 @@ test.describe("accessibility", () => {
 
   test("controls inside a closed modal are not reachable", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop", "one project is enough");
-    await openApp(page, testInfo.project.name);
+    await page.goto("/");
     // The overlays were hidden with opacity + pointer-events only, so every
     // control inside stayed in the tab order and the a11y tree, and their
     // headings polluted the document outline.

--- a/test/e2e/canvas-frame-probe.ts
+++ b/test/e2e/canvas-frame-probe.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 export type CanvasName = "curve" | "scatter";
 
@@ -173,7 +173,7 @@ export function expectAtMostOneDrawPerCanvasPerFrame(
   ).toBeLessThanOrEqual(1);
 }
 
-export async function hoverRenderedScatterPoint(page: Page): Promise<void> {
+export async function hoverRenderedScatterPoint(page: Page): Promise<Locator> {
   const canvas = page.locator("#scatter-canvas");
   const box = await canvas.boundingBox();
   if (!box) throw new Error("scatter canvas has no bounding box");
@@ -181,7 +181,7 @@ export async function hoverRenderedScatterPoint(page: Page): Promise<void> {
   for (let y = 30; y < box.height - 30; y += 8) {
     for (let x = 75; x < box.width - 20; x += 8) {
       await page.mouse.move(box.x + x, box.y + y);
-      if (await page.evaluate(() => window.__test?.hoveredPointIdx !== null)) return;
+      if (await page.evaluate(() => window.__test?.hoveredPointIdx !== null)) return canvas;
     }
   }
   throw new Error("could not locate a rendered scatter point");

--- a/test/e2e/canvas-scheduling.spec.ts
+++ b/test/e2e/canvas-scheduling.spec.ts
@@ -7,13 +7,21 @@ import {
   installCanvasFrameProbe,
   resetCanvasFrameProbe,
   snapshotCanvasFrames,
-  waitForCanvasAppReady,
   waitForCanvasLoopToPark,
 } from "./canvas-frame-probe";
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
-test.beforeEach(async ({ page }) => {
-  await installCanvasFrameProbe(page);
-});
+async function waitForCanvasModelReady(page: import("@playwright/test").Page) {
+  await page.waitForFunction(
+    () => window.__test?.modelReady === true,
+    null,
+    { timeout: 30_000 },
+  );
+  await waitForCanvasLoopToPark(page);
+}
 
 async function expectCurveOnly(page: import("@playwright/test").Page) {
   const snapshot = await snapshotCanvasFrames(page);
@@ -34,7 +42,10 @@ test.describe("canvas scheduling", () => {
     page,
   }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop interaction");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     await hoverRenderedScatterPoint(page);
     await resetCanvasFrameProbe(page);
 
@@ -52,7 +63,10 @@ test.describe("canvas scheduling", () => {
 
   test("slider preview and return redraw only the curve", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop hover interaction");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     const slider = page.locator("#sliders input[type=range]").nth(1);
     const box = await slider.boundingBox();
     if (!box) throw new Error("slider has no bounding box");
@@ -79,7 +93,10 @@ test.describe("canvas scheduling", () => {
     page,
   }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop hover interaction");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     const inactive = page.locator(".material-source-group .toggle-btn:not(.active)").first();
     await resetCanvasFrameProbe(page);
 
@@ -98,7 +115,10 @@ test.describe("canvas scheduling", () => {
 
   test("direct slider commit redraws scatter only at the boundary", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop interaction");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     const slider = page.locator("#sliders input[type=range]").first();
     await resetCanvasFrameProbe(page);
 
@@ -119,7 +139,10 @@ test.describe("canvas scheduling", () => {
     page,
   }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop interaction");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     const inactive = page.locator(".material-source-group .toggle-btn:not(.active)").first();
     await resetCanvasFrameProbe(page);
 
@@ -138,7 +161,10 @@ test.describe("canvas scheduling", () => {
   for (const selector of ["#axis-selector-x", "#axis-selector-y"]) {
     test(`${selector} transition redraws only scatter`, async ({ page }, testInfo) => {
       test.skip(!testInfo.project.name.startsWith("desktop"), "desktop scatter controls");
-      await waitForCanvasAppReady(page);
+      await installCanvasFrameProbe(page);
+      await page.goto("/?test=1");
+      await waitForDashboardLayoutReady(page);
+      await waitForCanvasModelReady(page);
       await resetCanvasFrameProbe(page);
 
       await page.locator(`${selector} .axis-option-face:has(input:not(:checked))`).click();
@@ -152,7 +178,10 @@ test.describe("canvas scheduling", () => {
   test("curve observation hover redraws only the curve", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop hover interaction");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     await resetCanvasFrameProbe(page);
 
     await hoverRenderedCurveObservation(page);
@@ -164,7 +193,10 @@ test.describe("canvas scheduling", () => {
 
   test("scatter hover redraws both canvases at most once per frame", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop hover interaction");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     await resetCanvasFrameProbe(page);
 
     await hoverRenderedScatterPoint(page);
@@ -179,7 +211,10 @@ test.describe("canvas scheduling", () => {
 
   test("theme and unit changes redraw both canvases", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop controls");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
 
     for (const selector of ["#theme-toggle", "#unit-toggle"]) {
       await resetCanvasFrameProbe(page);
@@ -197,7 +232,10 @@ test.describe("canvas scheduling", () => {
 
   test("resizing a chart container coordinates both desktop canvases", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop layout");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     await resetCanvasFrameProbe(page);
 
     await page.locator(".scatter-content").evaluate((element) => {
@@ -224,7 +262,10 @@ test.describe("canvas scheduling", () => {
 
   test("filter structural motion invalidates scatter only at transaction boundaries", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop filter controls");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     await resetCanvasFrameProbe(page);
     await page.evaluate(() => {
       document.body.dataset.layoutChangeCount = "0";
@@ -251,7 +292,10 @@ test.describe("canvas scheduling", () => {
 
   test("filters redraw only scatter", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop filter controls");
-    await waitForCanvasAppReady(page);
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
     await page.locator("#filter-add").click();
     await resetCanvasFrameProbe(page);
 
@@ -267,9 +311,11 @@ test.describe("canvas scheduling", () => {
 
   test("mobile scatter reveal invalidates only scatter", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("mobile"), "mobile-only");
-    await waitForCanvasAppReady(page);
-    await page.locator("#mobile-show-sliders").click();
-    await expect(page.locator(".mobile-sliders-view")).toBeVisible();
+    await installCanvasFrameProbe(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+    await waitForCanvasModelReady(page);
+    await openMobileComposition(page);
     await resetCanvasFrameProbe(page);
 
     await page.locator("#mobile-show-scatter").click();

--- a/test/e2e/dashboard-helpers.ts
+++ b/test/e2e/dashboard-helpers.ts
@@ -1,0 +1,28 @@
+import { expect, type Page } from "@playwright/test";
+
+export async function waitForDashboardLayoutReady(page: Page): Promise<void> {
+  await expect(page.locator("#sliders .slider-group").last()).toBeAttached({
+    timeout: 15_000,
+  });
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await Promise.all(
+      [...document.querySelectorAll(".fade-in-up")].flatMap((element) =>
+        element.getAnimations().map((animation) => animation.finished),
+      ),
+    );
+  });
+}
+
+export async function openMobileComposition(page: Page): Promise<void> {
+  const toggle = page.locator("#mobile-show-sliders");
+  if (await toggle.getAttribute("aria-pressed") === "false") {
+    await toggle.click();
+  }
+
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator(".mobile-sliders-view")).toBeVisible();
+  await expect(page.locator(".mobile-sliders-view")).not.toHaveAttribute("inert", /.*/);
+  await expect(page.locator(".scatter-content")).toBeHidden();
+  await expect(page.locator("#sliders input[type=range]").first()).toBeVisible();
+}

--- a/test/e2e/filter-motion.spec.ts
+++ b/test/e2e/filter-motion.spec.ts
@@ -1,16 +1,10 @@
 import { expect, test, type Page } from "@playwright/test";
+import { waitForDashboardLayoutReady } from "./dashboard-helpers";
 
 async function openDashboard(page: Page) {
   await page.goto("/?test=1");
-  await expect(page.locator("#filter-add")).toBeVisible({ timeout: 15_000 });
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-    await Promise.all(
-      [...document.querySelectorAll(".fade-in-up")].flatMap((element) =>
-        element.getAnimations().map((animation) => animation.finished),
-      ),
-    );
-  });
+  await waitForDashboardLayoutReady(page);
+  await expect(page.locator("#filter-add")).toBeVisible();
 }
 
 async function waitForFilterMotion(page: Page) {

--- a/test/e2e/header-layout.spec.ts
+++ b/test/e2e/header-layout.spec.ts
@@ -129,15 +129,16 @@ test.describe("header layout", () => {
     expect(before?.y).toBeLessThan(10);
 
     // Scroll the references panel into view (it's near the bottom of the page)
-    await page.locator(".references-panel").scrollIntoViewIfNeeded();
-    // Allow any scroll-snap / momentum to settle
-    await page.waitForTimeout(400);
+    const references = page.locator(".references-panel");
+    await references.scrollIntoViewIfNeeded();
+    await expect(references).toBeInViewport();
 
     // Header is still pinned at top (within a few px for sticky offset)
-    const after = await page.locator(".site-header").boundingBox();
-    expect(after?.y, "header should still be sticky at top after scrolling").toBeLessThan(
-      10,
-    );
+    await expect
+      .poll(() => page.locator(".site-header").evaluate(
+        (header) => header.getBoundingClientRect().top,
+      ))
+      .toBeLessThan(10);
   });
 
   test("mobile: page does not scroll horizontally when dragged left", async ({

--- a/test/e2e/home-loads.spec.ts
+++ b/test/e2e/home-loads.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForCanvasAppReady } from "./canvas-frame-probe";
 
 /**
  * Smoke tests — page loads cleanly with no errors and the core
@@ -13,13 +14,14 @@ test.describe("home page smoke", () => {
     });
     page.on("pageerror", (err) => errors.push(err.message));
 
-    await page.goto("/");
+    await waitForCanvasAppReady(page);
 
     await expect(page.locator("h1", { hasText: "BOxCrete" })).toBeVisible();
     await expect(page.locator("canvas#scatter-canvas")).toBeVisible();
     await expect(page.locator("canvas#curve-canvas")).toBeVisible();
 
-    // Wait for any deferred WASM/init work to settle, then assert no errors
+    // initWASM() is intentionally non-blocking and has no completion hook. Keep
+    // observing after model readiness so deferred startup errors still fail.
     await page.waitForTimeout(1500);
     expect(
       errors,

--- a/test/e2e/ingredient-insight.spec.ts
+++ b/test/e2e/ingredient-insight.spec.ts
@@ -1,18 +1,16 @@
 import { expect, test, type Page } from "@playwright/test";
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
 async function openComposition(page: Page, projectName: string) {
   await page.goto("/");
+  await waitForDashboardLayoutReady(page);
   if (projectName.startsWith("mobile")) {
-    await page.locator("#mobile-show-sliders").click();
-    await expect(page.locator(".mobile-sliders-view")).toBeVisible();
+    await openMobileComposition(page);
   }
   await expect(page.getByRole("button", { name: "Cement ingredient insight" })).toBeVisible();
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-    const panelAnimations = [...document.querySelectorAll(".fade-in-up")]
-      .flatMap((element) => element.getAnimations());
-    await Promise.all(panelAnimations.map((animation) => animation.finished));
-  });
 }
 
 test.describe("ingredient insight discovery", () => {

--- a/test/e2e/mobile-behavior.spec.ts
+++ b/test/e2e/mobile-behavior.spec.ts
@@ -85,10 +85,15 @@ test.describe("mobile behaviour", () => {
     await input.click();
     await input.fill("300");
     await input.press("Enter");
-    await page.waitForTimeout(700);
-    const committed = await page.evaluate(
-      (i) => (window as any).__test.currentComposition[Number(i)], idx);
-    expect(committed, "typed value should commit to the composition").toBeCloseTo(300, 0);
+    await expect
+      .poll(() => page.evaluate(
+        (i) => ({
+          value: (window as any).__test.currentComposition[Number(i)],
+          active: (window as any).__test.isCompositionTransitionActive,
+        }),
+        idx,
+      ))
+      .toEqual({ value: 300, active: false });
   });
 
   test("strength curve renders non-blank after interaction", async ({ page }) => {

--- a/test/e2e/mobile-behavior.spec.ts
+++ b/test/e2e/mobile-behavior.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "@playwright/test";
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
 /**
  * Mobile behavioural coverage.
@@ -14,6 +18,7 @@ import { test, expect } from "@playwright/test";
 
 async function openSliders(page: import("@playwright/test").Page) {
   await page.goto("/?test=1");
+  await waitForDashboardLayoutReady(page);
   await page.waitForFunction(() => typeof (window as any).__test !== "undefined");
   // The shell renders before the GP finishes building in the worker, so wait
   // for the model itself before asserting on predictions.
@@ -22,8 +27,7 @@ async function openSliders(page: import("@playwright/test").Page) {
     null,
     { timeout: 20000 },
   );
-  await page.locator("#mobile-show-sliders").click();
-  await expect(page.locator(".mobile-sliders-view")).toBeVisible({ timeout: 2000 });
+  await openMobileComposition(page);
 }
 
 test.describe("mobile behaviour", () => {

--- a/test/e2e/mobile-slider-layout.spec.ts
+++ b/test/e2e/mobile-slider-layout.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "@playwright/test";
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
 /**
  * Mobile-only: pin down the multi-row slider layout. Each `.slider-group`
@@ -25,10 +29,8 @@ test.describe("mobile slider multi-row layout", () => {
   test.beforeEach(async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("mobile"), "mobile-only layout");
     await page.goto("/");
-    // Switch to the Composition view (sliders are hidden by default on mobile)
-    await page.locator("#mobile-show-sliders").click();
-    await expect(page.locator(".mobile-sliders-view")).toBeVisible({ timeout: 2000 });
-    await expect(page.locator(".mobile-sliders-view .slider-group").first()).toBeVisible();
+    await waitForDashboardLayoutReady(page);
+    await openMobileComposition(page);
   });
 
   test("label, slider, and info-row stack vertically without overlap", async ({ page }) => {

--- a/test/e2e/mobile-slider-layout.spec.ts
+++ b/test/e2e/mobile-slider-layout.spec.ts
@@ -348,7 +348,21 @@ test.describe("mobile slider multi-row layout", () => {
     // Switch back to sliders view to inspect the markers
     await page.locator("#mobile-show-sliders").click();
     await expect(page.locator(".mobile-sliders-view")).toBeVisible();
-    await page.waitForTimeout(300);
+    await expect
+      .poll(() => page.evaluate(() => {
+        const groups = Array.from(document.querySelectorAll(".mobile-sliders-view .slider-group"));
+        return groups.every((group) => {
+          const slider = group.querySelector("input[type=range]") as HTMLElement | null;
+          const marker = group.querySelector(".slider-preview-marker") as HTMLElement | null;
+          if (!slider) return true;
+          if (!marker || marker.style.display === "none") return false;
+          const sliderRect = slider.getBoundingClientRect();
+          const markerRect = marker.getBoundingClientRect();
+          const markerCenter = markerRect.left + markerRect.width / 2;
+          return markerCenter >= sliderRect.left - 1 && markerCenter <= sliderRect.right + 1;
+        });
+      }))
+      .toBe(true);
 
     const verdict = await page.evaluate(() => {
       const groups = Array.from(document.querySelectorAll(".mobile-sliders-view .slider-group"));

--- a/test/e2e/mobile-value-fit.spec.ts
+++ b/test/e2e/mobile-value-fit.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "@playwright/test";
 import { waitForCanvasLoopToPark } from "./canvas-frame-probe";
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
 /**
  * Mobile-only overflow regression pin. A previous iteration of the slider
@@ -16,9 +20,8 @@ const ALLOWANCE_PX = 1;
 
 async function gotoSlidersView(page: import("@playwright/test").Page) {
   await page.goto("/?test=1");
-  await page.locator("#mobile-show-sliders").click();
-  await expect(page.locator(".mobile-sliders-view")).toBeVisible({ timeout: 2000 });
-  await expect(page.locator(".mobile-sliders-view .slider-group").first()).toBeVisible();
+  await waitForDashboardLayoutReady(page);
+  await openMobileComposition(page);
 }
 
 async function assertNoOverflow(page: import("@playwright/test").Page, label: string) {

--- a/test/e2e/mobile-value-fit.spec.ts
+++ b/test/e2e/mobile-value-fit.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForCanvasLoopToPark } from "./canvas-frame-probe";
 
 /**
  * Mobile-only overflow regression pin. A previous iteration of the slider
@@ -14,7 +15,7 @@ import { test, expect } from "@playwright/test";
 const ALLOWANCE_PX = 1;
 
 async function gotoSlidersView(page: import("@playwright/test").Page) {
-  await page.goto("/");
+  await page.goto("/?test=1");
   await page.locator("#mobile-show-sliders").click();
   await expect(page.locator(".mobile-sliders-view")).toBeVisible({ timeout: 2000 });
   await expect(page.locator(".mobile-sliders-view .slider-group").first()).toBeVisible();
@@ -98,7 +99,7 @@ test.describe("mobile slider value never overflows the panel", () => {
         }
       }
     });
-    await page.waitForTimeout(200);
+    await waitForCanvasLoopToPark(page);
     await assertNoOverflow(page, "fractional metric");
   });
 
@@ -108,8 +109,7 @@ test.describe("mobile slider value never overflows the panel", () => {
     await page.evaluate(() => {
       document.dispatchEvent(new CustomEvent("toggle-units"));
     });
-    // Wait through the 350ms unit transition
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
     await assertNoOverflow(page, "imperial default");
   });
 
@@ -125,7 +125,7 @@ test.describe("mobile slider value never overflows the panel", () => {
         s.dispatchEvent(new Event("input", { bubbles: true }));
       }
     });
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
     await assertNoOverflow(page, "imperial max-bound");
   });
 
@@ -136,7 +136,7 @@ test.describe("mobile slider value never overflows the panel", () => {
 
     // Imperial after toggle on the narrow viewport
     await page.evaluate(() => document.dispatchEvent(new CustomEvent("toggle-units")));
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
     await assertNoOverflow(page, "320px imperial");
 
     // Max-bound imperial on narrow viewport
@@ -149,7 +149,7 @@ test.describe("mobile slider value never overflows the panel", () => {
         s.dispatchEvent(new Event("input", { bubbles: true }));
       }
     });
-    await page.waitForTimeout(200);
+    await waitForCanvasLoopToPark(page);
     await assertNoOverflow(page, "320px imperial max-bound");
   });
 

--- a/test/e2e/og-meta.spec.ts
+++ b/test/e2e/og-meta.spec.ts
@@ -27,9 +27,8 @@ test.describe("Open Graph + Twitter Card metadata", () => {
     expect(await get('meta[name="twitter:image"]')).toContain("og-image.jpg");
   });
 
-  test("og-image.jpg loads as a JPEG within a reasonable size budget", async ({ page, request }, testInfo) => {
+  test("og-image.jpg loads as a JPEG within a reasonable size budget", async ({ request }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop", "asset fetch is identical across viewports");
-    await page.goto("/");
     const resp = await request.get("/og-image.jpg");
     expect(resp.status(), "og-image.jpg must be reachable").toBe(200);
     const ct = resp.headers()["content-type"] ?? "";

--- a/test/e2e/panel-geometry.spec.ts
+++ b/test/e2e/panel-geometry.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
+import { waitForDashboardLayoutReady } from "./dashboard-helpers";
 
 const GAP_TOLERANCE = 1;
 
@@ -15,15 +16,6 @@ type Metrics = {
   paddingBottom: number;
   tabIndex: number;
 };
-
-async function waitForDashboard(page: Page) {
-  await page.goto("/?test=1");
-  await expect(page.locator("#sliders .slider-group").last()).toBeAttached({ timeout: 15_000 });
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-    await Promise.all([...document.querySelectorAll(".fade-in-up")].flatMap((element) => element.getAnimations().map((animation) => animation.finished)));
-  });
-}
 
 async function metrics(locator: Locator): Promise<Metrics> {
   return locator.evaluate((element) => {
@@ -68,7 +60,10 @@ async function configuredGap(page: Page) {
 }
 
 test.describe("intrinsic capped dashboard panels", () => {
-  test.beforeEach(async ({ page }) => waitForDashboard(page));
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+  });
 
   test("desktop columns are top-aligned intrinsic stacks separated only by the configured gap", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop column contract");
@@ -103,7 +98,8 @@ test.describe("intrinsic capped dashboard panels", () => {
     test(`desktop Composition is intrinsic at ${viewport.width}x${viewport.height}`, async ({ page }, testInfo) => {
       test.skip(!testInfo.project.name.startsWith("desktop"), "desktop Composition contract");
       await page.setViewportSize(viewport);
-      await waitForDashboard(page);
+      await page.goto("/?test=1");
+      await waitForDashboardLayoutReady(page);
 
       const panel = page.locator("#sliders-panel");
       const body = page.locator("#sliders");
@@ -170,7 +166,8 @@ test.describe("intrinsic capped dashboard panels", () => {
   test("each managed panel cap leaves oversized content scrolling only in its established body", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "managed cap ownership contract");
     await page.setViewportSize({ width: 1728, height: 1000 });
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
 
     for (const contract of [
       { shell: "#mix-insight", body: ".mix-insight-body", cap: 14 * 16 },
@@ -203,7 +200,8 @@ test.describe("intrinsic capped dashboard panels", () => {
   test("References uses a stable viewport/header cap and keeps overflow in its list", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop References cap contract");
     await page.setViewportSize({ width: 1280, height: 700 });
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
 
     const readCap = () => page.evaluate(() => ({
       css: parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--references-usable-cap")),
@@ -293,7 +291,8 @@ test.describe("intrinsic capped dashboard panels", () => {
     const measurements: number[] = [];
     for (const height of [1000, 1117]) {
       await page.setViewportSize({ width: 1728, height });
-      await waitForDashboard(page);
+      await page.goto("/?test=1");
+      await waitForDashboardLayoutReady(page);
       measurements.push((await metrics(page.locator("#sliders-panel"))).height);
     }
     expect(Math.abs(measurements[1] - measurements[0])).toBeLessThanOrEqual(1);
@@ -302,7 +301,8 @@ test.describe("intrinsic capped dashboard panels", () => {
   test("desktop document scrolling reaches the final Composition control", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop document-scroll contract");
     await page.setViewportSize({ width: 1280, height: 700 });
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
     const finalControl = page.getByRole("button", { name: "Temperature ingredient insight" });
     const documentRange = await page.evaluate(() =>
       document.documentElement.scrollHeight - document.documentElement.clientHeight,

--- a/test/e2e/plot-geometry.spec.ts
+++ b/test/e2e/plot-geometry.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { waitForDashboardLayoutReady } from "./dashboard-helpers";
 
 type Geometry = {
   scatter: { canvas: DOMRectJSON; plot: DOMRectJSON };
@@ -15,19 +16,6 @@ type DOMRectJSON = {
   bottom: number;
   left: number;
 };
-
-async function waitForDashboard(page: Page) {
-  await page.goto("/?test=1");
-  await expect(page.locator("#sliders .slider-group").last()).toBeAttached({ timeout: 15_000 });
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-    await Promise.all(
-      [...document.querySelectorAll(".fade-in-up")].flatMap((element) =>
-        element.getAnimations().map((animation) => animation.finished),
-      ),
-    );
-  });
-}
 
 async function readGeometry(page: Page): Promise<Geometry> {
   return page.evaluate(async () => {
@@ -109,7 +97,8 @@ test.describe("shared plot geometry", () => {
       ? [{ width: 1900, height: 1000 }, { width: 1051, height: 900 }]
       : [{ width: 844, height: 390 }, { width: 412, height: 915 }]) {
       await page.setViewportSize(viewport);
-      await waitForDashboard(page);
+      await page.goto("/?test=1");
+      await waitForDashboardLayoutReady(page);
       await expect.poll(() => page.evaluate(() => {
         const selector = document.querySelector("#axis-selector-x")!.getBoundingClientRect();
         const canvas = document.querySelector<HTMLCanvasElement>("#scatter-canvas")! as HTMLCanvasElement & {
@@ -180,7 +169,8 @@ test.describe("shared plot geometry", () => {
       { width: 1051, height: 900 },
     ]) {
       await page.setViewportSize(viewport);
-      await waitForDashboard(page);
+      await page.goto("/?test=1");
+      await waitForDashboardLayoutReady(page);
       const geometry = await stableGeometry(page);
       expectLandscape(geometry);
       expectDesktopPeers(geometry);
@@ -196,7 +186,8 @@ test.describe("shared plot geometry", () => {
   test("crossing responsive and managed-laptop thresholds restores valid geometry", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop resize contract");
     await page.setViewportSize({ width: 1051, height: 900 });
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
     let beforeManaged: Geometry | null = null;
     for (const viewport of [
       { width: 1050, height: 900 },
@@ -243,7 +234,8 @@ test.describe("shared plot geometry", () => {
       { width: 844, height: 390 },
     ]) {
       await page.setViewportSize(viewport);
-      await waitForDashboard(page);
+      await page.goto("/?test=1");
+      await waitForDashboardLayoutReady(page);
       const geometry = await stableGeometry(page);
       expectLandscape(geometry);
       expect(Math.abs(geometry.scatter.plot.width - geometry.strength.plot.width)).toBeLessThanOrEqual(1);
@@ -254,7 +246,8 @@ test.describe("shared plot geometry", () => {
   test("visible Strength resizes while mobile Scatter is hidden", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("mobile"), "mobile hidden-view geometry contract");
     await page.setViewportSize({ width: 412, height: 915 });
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
     await page.locator("#mobile-show-sliders").click();
     await expect(page.locator(".scatter-content")).toBeHidden();
 
@@ -272,7 +265,8 @@ test.describe("shared plot geometry", () => {
   });
 
   test("canvas backing stores track CSS geometry and DPR after resize", async ({ page }) => {
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
     for (const viewport of [
       { width: 1280, height: 800 },
       { width: 1050, height: 900 },
@@ -303,7 +297,8 @@ test.describe("shared plot geometry", () => {
   test("opening References does not change scatter or strength geometry", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop cross-column geometry contract");
     await page.setViewportSize({ width: 1728, height: 1000 });
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
     const before = await stableGeometry(page);
 
     await page.locator(".ref-details > summary").first().click();
@@ -321,7 +316,8 @@ test.describe("shared plot geometry", () => {
   });
 
   test("filter count never changes scatter or strength geometry", async ({ page }) => {
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
     const before = await stableGeometry(page);
     const beforeScrollY = await page.evaluate(() => scrollY);
     const add = page.locator("#filter-add");

--- a/test/e2e/pre-model-shell.spec.ts
+++ b/test/e2e/pre-model-shell.spec.ts
@@ -85,9 +85,14 @@ test.describe("pre-model shell", () => {
     ).toBe(false);
     expect(clicked, "no scatter point was hoverable pre-model — hover is broken").toBe(true);
 
-    await page.waitForTimeout(800);
-    const after = await page.evaluate(() =>
-      JSON.stringify((window as any).__test.currentComposition));
-    expect(after, "clicking a point pre-model must still select it").not.toBe(before);
+    await expect
+      .poll(() => page.evaluate((previous) => {
+        const testState = (window as any).__test;
+        return {
+          changed: JSON.stringify(testState.currentComposition) !== previous,
+          active: testState.isCompositionTransitionActive,
+        };
+      }, before))
+      .toEqual({ changed: true, active: false });
   });
 });

--- a/test/e2e/preview-curve.spec.ts
+++ b/test/e2e/preview-curve.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForCanvasLoopToPark } from "./canvas-frame-probe";
 
 /**
  * Regression pin for two related Material Source toggle bugs:
@@ -105,8 +106,7 @@ test.describe("preview curve composition sync", () => {
 
     for (const idx of [1, 2, 0]) {
       await toggleButtons.nth(idx).click();
-      // Curve transition is 350ms; wait it out before sampling state.
-      await page.waitForTimeout(450);
+      await waitForCanvasLoopToPark(page);
       const result = await page.evaluate(() => {
         const t = (window as any).__test;
         return { current: t.currentComposition, preview: t.displayPreviewComp };
@@ -168,17 +168,39 @@ test.describe("mix insight refreshes on Material Source toggle", () => {
       },
       { timeout: 5000 },
     );
-    // Settle any in-flight content swap animation
-    await page.waitForTimeout(700);
+    await expect
+      .poll(() => insightText.evaluate((text) => {
+        const body = text.closest(".mix-insight-body")!;
+        const panel = text.closest("#mix-insight")!;
+        return {
+          populated: Boolean(text.textContent?.trim()),
+          ghosts: body.querySelectorAll(".content-swap-ghost").length,
+          running: panel
+            .getAnimations({ subtree: true })
+            .filter((animation) => animation.playState === "running").length,
+        };
+      }))
+      .toEqual({ populated: true, ghosts: 0, running: 0 });
     const before = (await insightText.textContent())?.trim() ?? "";
 
     // Click whichever Material Source toggle is currently inactive
     const inactive = page.locator(".material-source-group .toggle-btn:not(.active)");
     await inactive.first().click();
 
-    // Wait for: 350ms curve transition + 300ms scheduleInsightUpdate delay +
-    // 300ms content-swap animation = ~950ms. Use 1300ms to be safe.
-    await page.waitForTimeout(1300);
+    await expect
+      .poll(() => insightText.evaluate((text, previous) => {
+        const after = text.textContent?.trim() ?? "";
+        const body = text.closest(".mix-insight-body")!;
+        const panel = text.closest("#mix-insight")!;
+        return {
+          changed: after !== previous,
+          ghosts: body.querySelectorAll(".content-swap-ghost").length,
+          running: panel
+            .getAnimations({ subtree: true })
+            .filter((animation) => animation.playState === "running").length,
+        };
+      }, before))
+      .toEqual({ changed: true, ghosts: 0, running: 0 });
 
     const after = (await insightText.textContent())?.trim() ?? "";
 
@@ -188,9 +210,9 @@ test.describe("mix insight refreshes on Material Source toggle", () => {
     // placeholder text. The one thing it must NOT be is the same text as
     // before (which would indicate the bug).
     expect(
-      after === "" || after !== before,
+      after,
       `mix-insight-text must update on Material Source toggle (still: "${after.slice(0, 80)}...")`,
-    ).toBe(true);
+    ).not.toBe(before);
   });
 });
 
@@ -215,9 +237,17 @@ test.describe("strength curve transitions smoothly on Material Source toggle", (
     // The shell renders before the GP finishes building in the worker, so
     // wait for the model itself before asserting on predictions.
     await page.waitForFunction(() => (window as any).__test.modelReady === true, null, { timeout: 20000 });
-    await page.waitForTimeout(800); // settle initial fade-ins / WASM init
+    await waitForCanvasLoopToPark(page);
 
     const curve = page.locator("canvas#curve-canvas");
+    await expect
+      .poll(() => curve.evaluate((element) =>
+        element
+          .closest(".fade-in-up")
+          ?.getAnimations({ subtree: true })
+          .filter((animation) => animation.playState === "running").length ?? 0,
+      ))
+      .toBe(0);
     const before = await curve.screenshot();
 
     const inactive = page.locator(".material-source-group .toggle-btn:not(.active)").first();
@@ -1169,7 +1199,7 @@ test.describe("hover preview aligns with the committed prediction", () => {
     // The shell renders before the GP finishes building in the worker, so
     // wait for the model itself before asserting on predictions.
     await page.waitForFunction(() => (window as any).__test.modelReady === true, null, { timeout: 20000 });
-    await page.waitForTimeout(800);
+    await waitForCanvasLoopToPark(page);
 
     const canvas = page.locator("canvas#scatter-canvas");
     await expect(canvas).toBeVisible();
@@ -1221,7 +1251,7 @@ test.describe("hover preview aligns with the committed prediction", () => {
     // The shell renders before the GP finishes building in the worker, so
     // wait for the model itself before asserting on predictions.
     await page.waitForFunction(() => (window as any).__test.modelReady === true, null, { timeout: 20000 });
-    await page.waitForTimeout(800);
+    await waitForCanvasLoopToPark(page);
 
     const idx = msIdx >= 0 ? msIdx : await page.evaluate(async () => {
       const r = await fetch("model/compositions.json");

--- a/test/e2e/preview-curve.spec.ts
+++ b/test/e2e/preview-curve.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "@playwright/test";
-import { waitForCanvasLoopToPark } from "./canvas-frame-probe";
+import {
+  hoverRenderedScatterPoint,
+  waitForCanvasLoopToPark,
+} from "./canvas-frame-probe";
 
 /**
  * Regression pin for two related Material Source toggle bugs:
@@ -26,21 +29,6 @@ async function openPreviewTestPage(page: import("@playwright/test").Page) {
     await page.locator("#mobile-show-sliders").click();
   }
   await expect(firstSlider).toBeVisible();
-}
-
-async function hoverRenderedScatterPoint(page: import("@playwright/test").Page) {
-  const canvas = page.locator("#scatter-canvas");
-  const box = await canvas.boundingBox();
-  if (!box) throw new Error("scatter canvas has no bounding box");
-  for (let y = 30; y < box.height - 30; y += 8) {
-    for (let x = 75; x < box.width - 20; x += 8) {
-      await page.mouse.move(box.x + x, box.y + y);
-      if (await page.evaluate(() => (window as any).__test.hoveredPointIdx !== null)) {
-        return canvas;
-      }
-    }
-  }
-  throw new Error("could not locate a rendered scatter point");
 }
 
 async function waitForPreviewToSettle(page: import("@playwright/test").Page) {

--- a/test/e2e/reduced-motion.spec.ts
+++ b/test/e2e/reduced-motion.spec.ts
@@ -86,18 +86,18 @@ test.describe("reduced motion", () => {
   test("no infinite CSS animation is left running", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "one project is enough");
     await openReducedMotion(page);
-    await page.waitForTimeout(500);
 
-    const running = await page.evaluate(() =>
-      document
-        .getAnimations()
-        .filter((a) => a.playState === "running" && a.effect?.getTiming().iterations === Infinity)
-        .map((a) => (a as any).animationName || "unnamed"),
-    );
-    expect(
-      running,
-      `infinite animations still running under reduced motion: ${JSON.stringify(running)}`,
-    ).toEqual([]);
+    await expect
+      .poll(() => page.evaluate(() =>
+        document
+          .getAnimations()
+          .filter((animation) =>
+            animation.playState === "running" &&
+            animation.effect?.getTiming().iterations === Infinity
+          )
+          .map((animation) => (animation as any).animationName || "unnamed"),
+      ))
+      .toEqual([]);
   });
 
   test("the Material Source preview curve completes on the next frame", async ({ page }, testInfo) => {

--- a/test/e2e/references.spec.ts
+++ b/test/e2e/references.spec.ts
@@ -1,17 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-
-async function waitForDashboard(page: Page) {
-  await page.goto("/?test=1");
-  await expect(page.locator("#sliders .slider-group").first()).toBeAttached({ timeout: 15_000 });
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-    await Promise.all(
-      [...document.querySelectorAll(".fade-in-up")].flatMap((element) =>
-        element.getAnimations().map((animation) => animation.finished),
-      ),
-    );
-  });
-}
+import { waitForDashboardLayoutReady } from "./dashboard-helpers";
 
 async function overflowState(page: Page) {
   return page.locator(".ref-list").evaluate((element) => ({
@@ -21,7 +9,10 @@ async function overflowState(page: Page) {
 }
 
 test.describe("compact reference disclosures", () => {
-  test.beforeEach(async ({ page }) => waitForDashboard(page));
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+  });
 
   test("keeps bibliography and citation actions visible while descriptions are collapsed", async ({ page }) => {
     const disclosures = page.locator(".ref-details");
@@ -45,7 +36,8 @@ test.describe("compact reference disclosures", () => {
       ? { width: 1728, height: 1000 }
       : { width: 844, height: 390 };
     await page.setViewportSize(wide);
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
 
     const read = () => page.locator(".ref-item").first().evaluate((item) => {
       const content = item.querySelector(".ref-content")!.getBoundingClientRect();
@@ -302,7 +294,8 @@ test.describe("compact reference disclosures", () => {
   test("one open description grows naturally without local overflow when it fits", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop reference capacity contract");
     await page.setViewportSize({ width: 1728, height: 1000 });
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
     await page.locator(".ref-details > summary").first().click();
     await expect.poll(() => page.locator(".ref-description-motion").first().evaluate((element) =>
       element.getAnimations().length,
@@ -321,7 +314,8 @@ test.describe("compact reference disclosures", () => {
   test("oversized References stop at the usable cap and make only the list focusable", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop reference overflow contract");
     await page.setViewportSize({ width: 1280, height: 700 });
-    await waitForDashboard(page);
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
     await page.locator(".ref-list").evaluate((element) => {
       const filler = document.createElement("div");
       filler.dataset.testFiller = "true";

--- a/test/e2e/scatter-filter.spec.ts
+++ b/test/e2e/scatter-filter.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForDashboardLayoutReady } from "./dashboard-helpers";
 
 /**
  * Scatter filter UI invariants. Filters are a multi-row "+/−" interface
@@ -37,21 +38,9 @@ test.describe("scatter filter rows", () => {
 });
 
 test.describe("two-row filter viewport and focus containment", () => {
-  async function waitForDashboard(page: import("@playwright/test").Page) {
-    await expect(page.locator("#sliders .slider-group").first()).toBeAttached({ timeout: 15_000 });
-    await page.evaluate(async () => {
-      await document.fonts.ready;
-      await Promise.all(
-        [...document.querySelectorAll(".fade-in-up")].flatMap((element) =>
-          element.getAnimations().map((animation) => animation.finished),
-        ),
-      );
-    });
-  }
-
   test.beforeEach(async ({ page }) => {
     await page.goto("/?test=1");
-    await waitForDashboard(page);
+    await waitForDashboardLayoutReady(page);
   });
 
   async function waitForRows(page: import("@playwright/test").Page, count: number) {
@@ -106,7 +95,7 @@ test.describe("two-row filter viewport and focus containment", () => {
     ]) {
       await page.setViewportSize(scenario.viewport);
       await page.reload();
-      await waitForDashboard(page);
+      await waitForDashboardLayoutReady(page);
       const zero = await geometry(page);
       const snapshots = [zero];
       for (let count = 1; count <= scenario.expanded; count += 1) {

--- a/test/e2e/scatter-toggle.spec.ts
+++ b/test/e2e/scatter-toggle.spec.ts
@@ -1,19 +1,7 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
 import { waitForCanvasLoopToPark } from "./canvas-frame-probe";
-
-async function waitForDashboard(page: Page) {
-  await page.goto("/?test=1");
-  await expect(page.locator("#scatter-canvas")).toBeVisible({ timeout: 15_000 });
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-    await Promise.all(
-      [...document.querySelectorAll(".fade-in-up")].flatMap((element) =>
-        element.getAnimations().map((animation) => animation.finished),
-      ),
-    );
-  });
-}
+import { waitForDashboardLayoutReady } from "./dashboard-helpers";
 
 async function checkedValue(group: Locator) {
   return group.locator('input[type="radio"]:checked').inputValue();
@@ -370,7 +358,10 @@ async function assertGroupSemantics(group: Locator, legend: RegExp) {
 }
 
 test.describe("scatter plot two-option axis selectors", () => {
-  test.beforeEach(async ({ page }) => waitForDashboard(page));
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+  });
 
   test("both axis objectives remain visible with native radio semantics", async ({ page }) => {
     const x = page.locator("#axis-selector-x");

--- a/test/e2e/sliders.spec.ts
+++ b/test/e2e/sliders.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "@playwright/test";
+import {
+  waitForCanvasAppReady,
+  waitForCanvasLoopToPark,
+} from "./canvas-frame-probe";
 
 /**
  * Composition sliders — minimal sanity checks plus click-to-edit value
@@ -22,25 +26,7 @@ test.describe("composition sliders", () => {
 
   test("changing a slider triggers a strength curve redraw", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop", "desktop only");
-    await page.goto("/");
-    await expect(page.locator("#sliders .slider-group").first()).toBeVisible();
-    // A visible slider no longer implies a drawn curve: the shell renders
-    // before the GP resolves in the worker, and drawStrengthCurve bails while
-    // strengthParams is null. Baselining a blank canvas here would make the
-    // test pass because the MODEL arrived, not because the slider redrew.
-    await expect
-      .poll(
-        async () =>
-          await page.evaluate(() => {
-            const c = document.querySelector("canvas#curve-canvas") as HTMLCanvasElement;
-            if (!c) return false;
-            const d = c.getContext("2d")!.getImageData(0, 0, c.width, c.height).data;
-            for (let i = 3; i < d.length; i += 400) if (d[i] !== 0) return true;
-            return false;
-          }),
-        { timeout: 15000 },
-      )
-      .toBe(true);
+    await waitForCanvasAppReady(page);
 
     // Read initial pixel snapshot of the curve canvas
     const before = await page.locator("canvas#curve-canvas").screenshot();
@@ -54,8 +40,7 @@ test.describe("composition sliders", () => {
       el.dispatchEvent(new Event("input", { bubbles: true }));
       el.dispatchEvent(new Event("change", { bubbles: true }));
     });
-    // Allow render frame
-    await page.waitForTimeout(300);
+    await waitForCanvasLoopToPark(page);
 
     const after = await page.locator("canvas#curve-canvas").screenshot();
     expect(
@@ -73,8 +58,7 @@ test.describe("composition sliders", () => {
 test.describe("composition sliders — click-to-edit value input", () => {
   test.beforeEach(async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop", "desktop only");
-    await page.goto("/");
-    await expect(page.locator("#sliders .slider-group").first()).toBeVisible({ timeout: 5000 });
+    await waitForCanvasAppReady(page);
   });
 
   test("typing a value and pressing Enter commits to the slider and curve", async ({ page }) => {
@@ -84,13 +68,8 @@ test.describe("composition sliders — click-to-edit value input", () => {
     await page.keyboard.press("Control+A");
     await page.keyboard.type("350");
     await page.keyboard.press("Enter");
-    // Allow animateToComposition (350ms) to settle
-    await page.waitForTimeout(450);
-    const sliderValue = await page
-      .locator("#sliders input[type=range]")
-      .first()
-      .evaluate((el: HTMLInputElement) => el.value);
-    expect(parseFloat(sliderValue)).toBeGreaterThan(0);
+    const slider = page.locator("#sliders input[type=range]").first();
+    await waitForCanvasLoopToPark(page);
     const after = await page.locator("canvas#curve-canvas").screenshot();
     expect(Buffer.compare(before, after), "curve must change after committing edit").not.toBe(0);
   });
@@ -106,9 +85,8 @@ test.describe("composition sliders — click-to-edit value input", () => {
     await page.keyboard.type("999.9");
     await page.keyboard.press("Escape");
 
-    await page.waitForTimeout(100);
-    expect(await input.inputValue()).toBe(initialDisplay);
-    expect(await slider.evaluate((el: HTMLInputElement) => el.value)).toBe(initialSliderValue);
+    await expect(input).toHaveValue(initialDisplay);
+    await expect(slider).toHaveValue(initialSliderValue);
   });
 
   test("out-of-range value is clamped to the slider's [min, max]", async ({ page }) => {
@@ -120,7 +98,9 @@ test.describe("composition sliders — click-to-edit value input", () => {
     await page.keyboard.press("Control+A");
     await page.keyboard.type("99999");
     await page.keyboard.press("Enter");
-    await page.waitForTimeout(450);
+    await expect
+      .poll(() => slider.evaluate((element: HTMLInputElement) => Number(element.value)))
+      .toBeCloseTo(max, 0);
 
     const finalValue = await slider.evaluate((el: HTMLInputElement) => Number(el.value));
     // Slider clamps to max; allow 0.5 unit slop for floating-point rounding
@@ -138,10 +118,9 @@ test.describe("composition sliders — click-to-edit value input", () => {
     await page.keyboard.press("Control+A");
     await page.keyboard.type("not-a-number");
     await page.keyboard.press("Enter");
-    await page.waitForTimeout(200);
 
-    expect(await input.inputValue()).toBe(initialDisplay);
-    expect(await slider.evaluate((el: HTMLInputElement) => el.value)).toBe(initialSliderValue);
+    await expect(input).toHaveValue(initialDisplay);
+    await expect(slider).toHaveValue(initialSliderValue);
   });
 
   test("blur commits the edit (same as Enter)", async ({ page }) => {
@@ -155,7 +134,7 @@ test.describe("composition sliders — click-to-edit value input", () => {
     await page.keyboard.type("250");
     // Click somewhere outside the input to fire blur
     await page.locator("h1").click();
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
 
     const finalSliderValue = await slider.evaluate((el: HTMLInputElement) => Number(el.value));
     expect(finalSliderValue).not.toBe(initialSliderValue);
@@ -183,8 +162,7 @@ test.describe("composition sliders — click-to-edit value input", () => {
     // Trigger the unit toggle directly via the same custom event the buttons
     // fire — robust to whether desktop or mobile toggle button is visible.
     await page.evaluate(() => document.dispatchEvent(new CustomEvent("toggle-units")));
-    // Wait for the 350ms unit transition + 350ms compose animation
-    await page.waitForTimeout(800);
+    await waitForCanvasLoopToPark(page);
 
     // The committed value should reflect the typed `400` in the PRE-toggle
     // unit context (i.e., 400 kg/m³ is what we typed; the slider's internal

--- a/test/e2e/theme-toggle.spec.ts
+++ b/test/e2e/theme-toggle.spec.ts
@@ -6,13 +6,16 @@ import { test, expect } from "@playwright/test";
  *   2. Choice persists across reloads via localStorage.
  */
 test.describe("theme toggle", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      if (localStorage.getItem("boxcrete-theme") === null) {
+        localStorage.setItem("boxcrete-theme", "dark");
+      }
+    });
+  });
+
   test("clicking flips html[data-theme] between light and dark", async ({ page }) => {
     await page.goto("/");
-    // Force a known starting state
-    await page.evaluate(() => {
-      localStorage.setItem("boxcrete-theme", "dark");
-    });
-    await page.reload();
 
     const before = await page.evaluate(() =>
       document.documentElement.getAttribute("data-theme"),
@@ -32,8 +35,6 @@ test.describe("theme toggle", () => {
 
   test("theme choice persists across page reload", async ({ page }) => {
     await page.goto("/");
-    await page.evaluate(() => localStorage.setItem("boxcrete-theme", "dark"));
-    await page.reload();
 
     // Toggle to light, then reload and confirm it stuck
     await page.locator("#theme-toggle").click();

--- a/test/e2e/touch-targets.spec.ts
+++ b/test/e2e/touch-targets.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "@playwright/test";
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
 /**
  * Touch-target sizing.
@@ -16,19 +20,11 @@ const WCAG_MIN = 24;
 const HIG_MIN = 44;
 
 test.describe("slider touch targets", () => {
-  // Sliders are built after the model resolves, which now happens in a worker.
-  // Wait on the element rather than a timeout so the assertion measures a
-  // rendered slider instead of racing an empty panel.
-  async function waitForSliders(page: import("@playwright/test").Page, sel: string) {
-    await expect(page.locator(sel).first()).toBeVisible({ timeout: 15000 });
-  }
-
   test("mobile sliders meet the Apple HIG 44px target height", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("mobile"), "mobile touch sizing");
     await page.goto("/");
-    await page.locator("#mobile-show-sliders").click();
-    await expect(page.locator(".mobile-sliders-view")).toBeVisible({ timeout: 2000 });
-    await waitForSliders(page, ".mobile-sliders-view input[type=range]");
+    await waitForDashboardLayoutReady(page);
+    await openMobileComposition(page);
 
     const heights = await page.evaluate(() =>
       Array.from(document.querySelectorAll(".mobile-sliders-view input[type=range]"))
@@ -71,7 +67,7 @@ test.describe("slider touch targets", () => {
   test("desktop sliders meet the WCAG 2.2 AA 24px minimum", async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.startsWith("desktop"), "desktop pointer sizing");
     await page.goto("/");
-    await waitForSliders(page, "#sliders input[type=range]");
+    await waitForDashboardLayoutReady(page);
     const heights = await page.evaluate(() =>
       Array.from(document.querySelectorAll("input[type=range]"))
         .filter((el) => (el as HTMLElement).offsetParent !== null)

--- a/test/e2e/unit-toggle.spec.ts
+++ b/test/e2e/unit-toggle.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForCanvasLoopToPark } from "./canvas-frame-probe";
 
 /**
  * Unit-toggle behaviour for the composition setter panel:
@@ -15,7 +16,7 @@ import { test, expect } from "@playwright/test";
 test.describe("composition panel — unit toggle", () => {
   test.beforeEach(async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop", "desktop only");
-    await page.goto("/");
+    await page.goto("/?test=1");
     await expect(page.locator("#sliders .slider-group").first()).toBeVisible({
       timeout: 5000,
     });
@@ -36,8 +37,7 @@ test.describe("composition panel — unit toggle", () => {
     await page.evaluate(() =>
       document.dispatchEvent(new CustomEvent("toggle-units")),
     );
-    // Wait for the 350ms unit transition to settle
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
     const units = await page.locator("#sliders .slider-unit").allInnerTexts();
     expect(units).toContain("lb/yd³");
     expect(units).toContain("°F");
@@ -61,7 +61,7 @@ test.describe("composition panel — unit toggle", () => {
     await page.evaluate(() =>
       document.dispatchEvent(new CustomEvent("toggle-units")),
     );
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
 
     const valueAfter = await tempRow.locator(".slider-value").inputValue();
     const fahrenheit = parseFloat(valueAfter);
@@ -83,11 +83,11 @@ test.describe("composition panel — unit toggle", () => {
     await page.evaluate(() =>
       document.dispatchEvent(new CustomEvent("toggle-units")),
     );
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
     await page.evaluate(() =>
       document.dispatchEvent(new CustomEvent("toggle-units")),
     );
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
 
     const after = await tempRow.locator(".slider-value").inputValue();
     expect(parseFloat(after)).toBeCloseTo(parseFloat(before), 1);
@@ -106,7 +106,7 @@ test.describe("composition panel — unit toggle", () => {
     await page.evaluate(() =>
       document.dispatchEvent(new CustomEvent("toggle-units")),
     );
-    await page.waitForTimeout(450);
+    await waitForCanvasLoopToPark(page);
     const imperialBounds = (await tempRow.locator(".info-row span").allInnerTexts()).map(
       (s) => parseInt(s, 10),
     );

--- a/test/e2e/visual-effects.spec.ts
+++ b/test/e2e/visual-effects.spec.ts
@@ -1,25 +1,19 @@
 import { expect, test } from "@playwright/test";
 import { expectEffectInsideClippingAncestors } from "./effect-envelope";
-
-async function waitForDashboard(page: import("@playwright/test").Page) {
-  await page.goto("/?test=1");
-  await expect(page.locator("#sliders .slider-group").last()).toBeAttached({ timeout: 15_000 });
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-    await Promise.all(
-      [...document.querySelectorAll(".fade-in-up")].flatMap((element) =>
-        element.getAnimations().map((animation) => animation.finished),
-      ),
-    );
-  });
-}
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
 test.describe("all-sided visual-effect safe areas", () => {
-  test.beforeEach(async ({ page }) => waitForDashboard(page));
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/?test=1");
+    await waitForDashboardLayoutReady(page);
+  });
 
   test("Material Source preview pulse and hover lift fit every clipping ancestor", async ({ page }) => {
     if (await page.locator("#sliders").isHidden()) {
-      await page.locator("#mobile-show-sliders").click();
+      await openMobileComposition(page);
     }
     for (const button of await page.locator(".material-source-group .toggle-btn").all()) {
       await button.scrollIntoViewIfNeeded();
@@ -29,7 +23,7 @@ test.describe("all-sided visual-effect safe areas", () => {
 
   test("Composition edge controls reserve their outward focus envelopes", async ({ page }) => {
     if (await page.locator("#sliders").isHidden()) {
-      await page.locator("#mobile-show-sliders").click();
+      await openMobileComposition(page);
     }
     for (const control of [
       page.locator("#sliders input[type=range]").first(),

--- a/test/e2e/visual-regression.spec.ts
+++ b/test/e2e/visual-regression.spec.ts
@@ -1,4 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
+import {
+  openMobileComposition,
+  waitForDashboardLayoutReady,
+} from "./dashboard-helpers";
 
 async function freezeVisualMotion(page: Page) {
   await page.addStyleTag({
@@ -13,8 +17,7 @@ async function freezeVisualMotion(page: Page) {
 
 async function settleDashboard(page: Page) {
   await page.goto("/");
-  await expect(page.locator("#sliders .slider-group").last()).toBeAttached({ timeout: 15_000 });
-  await page.evaluate(() => document.fonts.ready);
+  await waitForDashboardLayoutReady(page);
   await expect
     .poll(() =>
       page.locator("#curve-canvas").evaluate((canvas: HTMLCanvasElement) => {
@@ -56,8 +59,7 @@ test.describe("@visual fixed-dashboard snapshots", () => {
   test("mobile Composition at local scroll boundaries", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "mobile", "mobile Composition baselines");
     await settleDashboard(page);
-    await page.locator("#mobile-show-sliders").click();
-    await expect(page.locator(".mobile-sliders-view")).toBeVisible();
+    await openMobileComposition(page);
     const panel = page.locator("#tradeoffs-panel");
     const body = page.locator(".mobile-scroll-content");
     await panel.evaluate((element) => element.scrollIntoView({ block: "center" }));
@@ -93,8 +95,7 @@ test.describe("@visual fixed-dashboard snapshots", () => {
     test.skip(testInfo.project.name !== "mobile", "narrow mobile layout crop");
     await page.setViewportSize({ width: 320, height: 720 });
     await settleDashboard(page);
-    await page.locator("#mobile-show-sliders").click();
-    await expect(page.locator(".mobile-sliders-view")).toBeVisible();
+    await openMobileComposition(page);
     await expect(page.locator("#tradeoffs-panel")).toHaveScreenshot("composition-mobile-320.png");
   });
 


### PR DESCRIPTION
Draft. Pure test-infrastructure change — no production code touched. **This is the only one of the four in-flight explorer branches that merges cleanly with `main` today**, so it should land first: it de-risks the e2e suite for the other three.

## What this does

- **`test-e2e-all`** — `make test-e2e` claimed to mirror `e2e.yml` while running only 2 of the 4 Playwright projects. `test-e2e` is now the fast Chromium loop; the new `test-e2e-all` runs all four (desktop, mobile, mobile-webkit, desktop-webkit) and `check-all` uses it.
- **Deterministic waits** — removes arbitrary timeouts across 20+ specs in favour of waiting on real state.
- **`test/e2e/dashboard-helpers.ts`** — `waitForDashboardLayoutReady` (waits for the last slider group, then `document.fonts.ready` and all `.fade-in-up` animations; font loading was a recurring source of geometry flake) and `openMobileComposition` (idempotent, asserts the full post-condition rather than clicking and hoping).

## One deliberate de-claim

The Makefile header no longer says "full local CI parity". It now states that `check-all` covers the same suites and projects as CI but does **not** reproduce runner, artifact, job-topology or branch-protection behaviour. That claim was actively misleading: `visual-regression.spec.ts` skips on macOS, so a green local `check-all` on a Mac says nothing about the Linux-rendered baselines.

## Verification

macOS arm64 at `1bd6e19`, sequential with `CI=1`:

| Check | Result |
|---|---|
| `make lint` | PASS |
| `make test-js` | PASS — 14/14 |
| `make test-py` | PASS — 270 passed, 141 subtests |
| e2e desktop+mobile | **PASS — 317 passed** |

Not covered locally: `visual-regression.spec.ts` skips on macOS; the two WebKit projects were not run.

## Notes for reviewers

- Running e2e in two git worktrees at once **silently tests the wrong checkout** — Playwright's `reuseExistingServer` is on locally and the port is hardcoded to 4173. A fix (`BOXCRETE_TEST_PORT`) exists on `feature/pareto-similarity-encoding`.
- Once this lands, `feature/explorer-slump-prediction` should replace its hand-rolled mobile-panel opening with `openMobileComposition`.