### PR TITLE
[WIP] Encode recipe similarity as fill density in the Pareto scatter

### DIFF
--- a/.github/workflows/js-sync.yml
+++ b/.github/workflows/js-sync.yml
@@ -29,6 +29,7 @@ on:
       - 'docs/gp_v2_fast.mjs'
       - 'docs/feature_registry.mjs'
       - 'docs/units.mjs'
+      - 'docs/similarity.mjs'
       - 'docs/model/**'
       - 'boxcrete/features.py'
       - 'package.json'
@@ -44,6 +45,7 @@ on:
       - 'test/fixtures/feature_parity_fixture.json'
       - 'test/test_curve_monotonicity.mjs'
       - 'test/test_data_freshness.mjs'
+      - 'test/test_js_similarity.mjs'
       - '.github/workflows/js-sync.yml'
   pull_request:
     branches: [main, master]
@@ -103,3 +105,6 @@ jobs:
 
       - name: Scatter filter predicate + derived quantities
         run: node test/test_js_filters.mjs
+
+      - name: Recipe-similarity metric (kernel parity + dynamic range)
+        run: node test/test_js_similarity.mjs

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,8 @@ JS_TESTS = \
   test/test_data_freshness.mjs \
   test/test_js_preview_state.mjs \
   test/test_js_categorical_source.mjs \
-  test/test_js_filters.mjs
+  test/test_js_filters.mjs \
+  test/test_js_similarity.mjs
 
 test-js:
 	@for t in $(JS_TESTS); do \

--- a/docs/design/pareto-similarity.md
+++ b/docs/design/pareto-similarity.md
@@ -1,0 +1,148 @@
+# Recipe-similarity encoding in the Pareto scatter
+
+Written against `02b1a2b` (branch `feature/pareto-similarity-encoding`, forked from
+`18d9792`).
+
+## Status
+
+Feature-complete: metric, rendering, toggle, unit tests, and a 14-invariant e2e spec.
+**Not yet reviewed or landed.** See the PR description for current test results.
+
+## Problem
+
+The Pareto scatter plots GWP-or-cost against strength. Two points sitting next to each other
+may be chemically unrelated mixes that merely happen to land in the same place. A user
+holding a composition cannot tell which of the nearby frontier mixes are **realistic
+substitutions** for what they have.
+
+## Approach
+
+Fade each catalog point's **fill** by how unlike the selected recipe it is, while keeping the
+**outline** at full opacity in the point's own hue. Hue and radius keep their existing Pareto
+meaning.
+
+Keeping the outline solid means position and contrast never degrade — a point can go hollow
+but never invisible, which a plain alpha fade cannot promise (`docs/ui.mjs:2120-2127`).
+
+### The metric is the GP's own kernel
+
+`docs/similarity.mjs` computes the **normalized composition kernel of the production strength
+GP** — the model's believed correlation between two mixes, in [0,1]:
+
+```js
+const kb = matern52ActiveDims(z1, z2, b.active_dims, b.lengthscales, b.outputscale);
+const ks = matern52ActiveDims(z1, z2, s.active_dims, s.lengthscales, s.outputscale)
+         * hammingFactor(src1, src2, params);
+return (kb + ks) / (b.outputscale + s.outputscale);
+```
+
+Normalizing by the sum of outputscales is exact because Matérn-5/2 self-similarity *is* the
+outputscale, so `s(x,x) === 1`.
+
+**Why not Euclidean or cosine.** The GP's lengthscales are *learned* — it already knows that
+Temp matters less than Cement — and it treats Material Source as an unordered categorical via
+a Hamming factor rather than a number. A hand-rolled metric would need hand-chosen dimension
+weights and would wrongly make source `0→2` twice as far as `0→1`. Nothing here is hand-tuned
+except the presentation mapping.
+
+**The time branch is deliberately excluded.** Two mixes are always compared at the same curing
+day, so the `h(t)` gate cancels in the normalization and `RBF_time` reduces to its outputscale
+— a constant 0.4578 of the 0.5245 total. Folding it in would compress every similarity into
+[0.907, 1.000], rendering as a uniform plot rather than an obviously broken one. A unit test
+asserts `min < 0.40` specifically to catch that mistake.
+
+### Contrast stretch
+
+Raw catalog similarities span [0.267, 1.0] but with an interquartile range of only
+[0.637, 0.828] — mapped straight to alpha, every point would render ~70% solid, i.e. no
+visible encoding. So (`similarity.mjs:29-34, 75-79`):
+
+```
+t = clamp((s − 0.25) / (1 − 0.25));   alpha = 0.06 + 0.94 · t^2.0
+```
+
+`SIMILARITY_FLOOR = 0.25` (empirical catalog min is 0.267), `SIMILARITY_GAMMA = 2.0`
+(1.0 leaves everything solid, 3.0 leaves everything hollow), `FILL_ALPHA_MIN = 0.06`. This
+spreads a rendered frame across roughly [0.18, 0.95], and a test asserts the spread across a
+real frame exceeds 0.5 — that assertion is the actual anti-regression guard on the gamma.
+
+### Caching
+
+Two-level, mirroring the existing `_paretoCache` (`docs/ui.mjs:1923-1946`). Keyed on
+`scatterDay | composition`. The `sims` array invalidates on any composition or day change,
+but the expensive `ctx` (the transformed catalog) is **retained across composition changes**
+and rebuilt only when the curing day changes. So a slider drag runs 149 kernel evaluations
+and zero input transforms. Recomputing all 149 similarities costs ~11 µs; rebuilding the
+context costs ~0.04 ms.
+
+The reference is the **committed** composition, deliberately not the hover preview —
+re-centring on hover would churn the whole field whenever the cursor crossed a point.
+
+`sims === null` is the single "encoding inactive" signal that `drawScatter` branches on.
+
+## Key invariants
+
+Unit tests in `test/test_js_similarity.mjs` (hand-rolled `check()`, exit gate must stay last):
+
+| Invariant | Note |
+|---|---|
+| `s(x,x) === 1`, symmetric, all 149×149 finite in [0,1] | |
+| **`min < 0.40`** | catches the RBF_time-folded-in regression |
+| source `0→1` equals `0→2` | Hamming, not ordinal |
+| strictly decreasing under growing Cement perturbation | |
+| Temp is part of the metric | explicit product requirement |
+| **reconstructs `gp.mjs::kernel()` to < 1e-10** | the kernel-parity pin |
+| rendered alpha spread across a frame > 0.5 | guards the gamma choice |
+| top-5 nearest neighbours of mix #0 === `[0,16,22,19,15]` | exact ordinal equality |
+| off-catalog reference stays finite | a dragged slider sits between catalog points |
+
+The golden neighbour list is an **inline constant**, not a fixture file, and is a rank test
+rather than a numeric one — insensitive to FP noise, maximally sensitive to lengthscale
+changes. Regenerate deliberately, and review the diff, if the strength model is retrained.
+
+The 14 e2e invariants are enumerated in `test/e2e/README.md`, per that file's house rule that
+every spec maps to at least one named invariant.
+
+## Traps
+
+- **Run parallel worktrees on different ports.** `playwright.config.ts` reads
+  `BOXCRETE_TEST_PORT` (default 4173) and `reuseExistingServer` is on locally, so a server
+  left running by another checkout is silently reused — and the suite then tests *that*
+  checkout's `docs/`, which presents as inexplicable assertion failures. Use
+  `BOXCRETE_TEST_PORT=4183 npm run test:e2e`. This mechanism was added on this branch, almost
+  certainly after being bitten by it.
+
+- **The metric is coupled to the shipped model artifact.** Retraining the strength GP changes
+  similarities, the golden neighbour list, and possibly the calibrated floor. The kernel-parity
+  test is what stops `similarity.mjs` and `gp.mjs` drifting apart.
+
+- **Filtered-out points are categorically different from dissimilar ones.** They are drawn
+  first, in grey, and excluded from the similarity reorder. Exclusion must never read as
+  "far away".
+
+- **The toggle handler must call `invalidateCanvases(CANVAS_SCATTER)`, not `drawScatter()`.**
+  Canvas renderers stay owned by `requestAnimationFrame`, which `test/e2e/canvas-frame-probe.ts`
+  asserts.
+
+- **Dangling reference.** `similarity.mjs:69-70` cites "the plan's gamma table" for the 1.0 /
+  3.0 alternatives. That plan is not in the repo — the repo gitignores `*.plan.md`
+  (`.gitignore:72`), so it was scratch and is now lost. The two rejected gamma values are
+  recorded in the constants' comments, which is the surviving record.
+
+## What's left
+
+- Rebase onto `main` (forked at `18d9792`). Expect conflicts in `Makefile`,
+  `docs/index.html`, `docs/style.css`, `docs/ui.mjs`, `playwright.config.ts`.
+- Verify against `main`'s current four-project Playwright matrix; the e2e spec is scoped
+  `desktop` only, so WebKit behaviour of the alpha encoding is unverified.
+- Similarity state is in-memory only, deliberately not persisted — revisit only if the axis
+  and unit toggles start persisting too.
+
+## How to verify
+
+```bash
+npm ci
+node test/test_js_similarity.mjs
+make test-js
+BOXCRETE_TEST_PORT=4183 npx playwright test test/e2e/pareto-similarity.spec.ts --project=desktop
+```

--- a/docs/gp.mjs
+++ b/docs/gp.mjs
@@ -610,4 +610,4 @@ export function predictCost(composition, costParams) {
 }
 
 // Export kernel functions for testing
-export { matern52, rbf, kernel, transformInput, solveTriangularLower, cholesky };
+export { matern52, matern52ActiveDims, rbf, kernel, transformInput, solveTriangularLower, cholesky };

--- a/docs/index.html
+++ b/docs/index.html
@@ -193,6 +193,9 @@
         <div class="controls" id="scatter-controls">
           <span>X: <span class="axis-toggle" id="toggle-x">GWP</span></span>
           <span>Y: <span class="axis-toggle" id="toggle-day">28-day strength</span></span>
+          <span>Similar: <button type="button" class="axis-toggle similarity-toggle"
+                  id="toggle-similarity" aria-pressed="true"
+                  title="Fade mixes whose recipe differs from the one you have selected">on</button></span>
           <span class="filter-actions">
             <span class="filter-label">Filter</span>
             <button id="filter-add" class="filter-add-btn" title="Add filter">+</button>

--- a/docs/similarity.mjs
+++ b/docs/similarity.mjs
@@ -97,3 +97,52 @@ export function compositionSimilarity(comp1, comp2, params, curingDay) {
     params,
   );
 }
+
+/**
+ * Precompute the transformed catalog once, so a per-frame similarity sweep is a
+ * kernel evaluation rather than 149 input transforms.
+ *
+ * The transform depends on the curing day (through the time dim and
+ * `log_maturity_robust`), so callers rebuild when the displayed day changes. The
+ * practical difference is small — max |s(day 1) − s(day 28)| is about 0.0015 —
+ * but the rebuild costs 0.04 ms, so we stay exact rather than approximate.
+ *
+ * @param {number[][]} compositions - catalog of 9-dim compositions.
+ * @param {object|null} params - parsed strength.json.
+ * @param {number} curingDay - day to evaluate at.
+ * @returns {{curingDay: number, transformed: number[][], sources: number[]}|null}
+ */
+export function buildSimilarityContext(compositions, params, curingDay) {
+  if (!params || !compositions) return null;
+  const srcDim = params.source_dim_raw;
+  return {
+    curingDay,
+    transformed: compositions.map((c) => transformInput([...c, curingDay], params)),
+    sources: compositions.map((c) => c[srcDim]),
+  };
+}
+
+/**
+ * Similarity of every catalog mix to `currentComp`.
+ *
+ * @param {number[]} currentComp - the 9-dim reference composition.
+ * @param {object|null} ctx - from `buildSimilarityContext`.
+ * @param {object|null} params - parsed strength.json.
+ * @returns {Float64Array|null} null when the model or context is unavailable.
+ */
+export function computeSimilarities(currentComp, ctx, params) {
+  if (!params || !ctx) return null;
+  const zCur = transformInput([...currentComp, ctx.curingDay], params);
+  const srcCur = currentComp[params.source_dim_raw];
+  const out = new Float64Array(ctx.transformed.length);
+  for (let i = 0; i < ctx.transformed.length; i++) {
+    out[i] = similarityFromTransformed(
+      zCur,
+      ctx.transformed[i],
+      srcCur,
+      ctx.sources[i],
+      params,
+    );
+  }
+  return out;
+}

--- a/docs/similarity.mjs
+++ b/docs/similarity.mjs
@@ -1,0 +1,80 @@
+/**
+ * Recipe-similarity between concrete mixes, as the deployed strength GP sees it.
+ *
+ * DOM-free so it can be unit tested under node. `docs/ui.mjs` touches the DOM at
+ * module scope and cannot be imported outside a browser, which is why the pure
+ * pieces live in siblings like this one (see `preview_state.mjs`).
+ *
+ * WHAT THE METRIC IS
+ * ------------------
+ * The strength GP's own normalized composition kernel — the model's believed
+ * correlation between two mixes. It is a single learned joint metric: ARD
+ * lengthscales over the continuous dims, plus a learned categorical weight for
+ * Material Source (`source_correlation`), combined by the learned outputscales.
+ * Nothing here is hand-tuned except the presentation mapping at the bottom.
+ *
+ * WHY THE TIME BRANCH IS EXCLUDED
+ * -------------------------------
+ * The production kernel (`gp.mjs:kernel`) is
+ *   h(t1) * (M_blind + M_specific * hamming + RBF_time) * h(t2)
+ * Two mixes are always compared at the same curing day, so the h(t) gate cancels
+ * in the normalization and RBF_time reduces to its outputscale — a constant
+ * 0.4578 out of the 0.5245 total. Including it would compress every similarity
+ * into [0.907, 1.000], which renders as a uniform plot rather than an obviously
+ * broken one. `test/test_js_similarity.mjs` pins the resulting dynamic range so
+ * this cannot silently regress.
+ */
+import { matern52ActiveDims, transformInput } from "./gp.mjs";
+
+/** Raw similarity at or below this renders fully hollow. Empirical catalog min is 0.267. */
+export const SIMILARITY_FLOOR = 0.25;
+/** Contrast exponent. 1.0 leaves everything looking solid, 3.0 leaves everything hollow. */
+export const SIMILARITY_GAMMA = 2.0;
+/** Fill alpha of the least similar mix. The outline carries position regardless. */
+export const FILL_ALPHA_MIN = 0.06;
+
+function hammingFactor(src1, src2, params) {
+  const ms = params.matern_specific;
+  if (!ms || ms.source_kernel_kind !== "hamming") return 1.0;
+  return src1 === src2 ? 1.0 : ms.source_correlation;
+}
+
+/**
+ * Hot path: both inputs already run through `transformInput`.
+ *
+ * @param {number[]} z1 - transformed 17-dim vector.
+ * @param {number[]} z2 - transformed 17-dim vector.
+ * @param {number} src1 - raw Material Source class of the first mix.
+ * @param {number} src2 - raw Material Source class of the second mix.
+ * @param {object} params - parsed strength.json.
+ * @returns {number} similarity in [0, 1].
+ */
+export function similarityFromTransformed(z1, z2, src1, src2, params) {
+  const b = params.matern_blind;
+  const s = params.matern_specific;
+  const kb = matern52ActiveDims(z1, z2, b.active_dims, b.lengthscales, b.outputscale);
+  const ks =
+    matern52ActiveDims(z1, z2, s.active_dims, s.lengthscales, s.outputscale) *
+    hammingFactor(src1, src2, params);
+  return (kb + ks) / (b.outputscale + s.outputscale);
+}
+
+/**
+ * Normalized composition kernel between two 9-dim compositions at a fixed curing day.
+ *
+ * @param {number[]} comp1 - 9-dim composition.
+ * @param {number[]} comp2 - 9-dim composition.
+ * @param {object|null} params - parsed strength.json, or null before the model loads.
+ * @param {number} curingDay - day both mixes are evaluated at.
+ * @returns {number|null} similarity in [0, 1], or null when the model is unavailable.
+ */
+export function compositionSimilarity(comp1, comp2, params, curingDay) {
+  if (!params || !params.matern_blind || !params.matern_specific) return null;
+  return similarityFromTransformed(
+    transformInput([...comp1, curingDay], params),
+    transformInput([...comp2, curingDay], params),
+    comp1[params.source_dim_raw],
+    comp2[params.source_dim_raw],
+    params,
+  );
+}

--- a/docs/similarity.mjs
+++ b/docs/similarity.mjs
@@ -60,6 +60,25 @@ export function similarityFromTransformed(z1, z2, src1, src2, params) {
 }
 
 /**
+ * Map raw kernel similarity to a fill alpha.
+ *
+ * Raw catalog similarities occupy [0.267, 1.0], but with an interquartile range
+ * of only [0.637, 0.828] — mapping them straight to alpha would render every
+ * point at roughly 70% solid, i.e. no visible encoding at all. Shifting by the
+ * floor and applying gamma 2.0 spreads a rendered frame across roughly
+ * [0.18, 0.95]. Calibrated against the shipped catalog; see the plan's gamma
+ * table for the 1.0 (too flat) and 3.0 (too harsh) alternatives.
+ *
+ * @param {number} s - raw similarity, nominally in [0, 1].
+ * @returns {number} fill alpha in [FILL_ALPHA_MIN, 1].
+ */
+export function similarityToFillAlpha(s) {
+  if (!Number.isFinite(s)) return FILL_ALPHA_MIN;
+  const t = Math.min(1, Math.max(0, (s - SIMILARITY_FLOOR) / (1 - SIMILARITY_FLOOR)));
+  return FILL_ALPHA_MIN + (1 - FILL_ALPHA_MIN) * Math.pow(t, SIMILARITY_GAMMA);
+}
+
+/**
  * Normalized composition kernel between two 9-dim compositions at a fixed curing day.
  *
  * @param {number[]} comp1 - 9-dim composition.

--- a/docs/style.css
+++ b/docs/style.css
@@ -915,6 +915,9 @@ h2 {
   align-items: center;
   font-size: 0.8rem;
   margin-top: 0.5rem;
+  /* Four items since the similarity toggle landed; without wrapping the row
+     overflows the narrow mobile viewport. */
+  flex-wrap: wrap;
 }
 .controls select, .controls button {
   font-size: 0.8rem;
@@ -1335,6 +1338,30 @@ a.ref-link {
 }
 .axis-toggle:hover {
   opacity: 0.7;
+}
+
+/* The similarity toggle is a real <button> so it is keyboard operable, but it
+   must read as one of the dashed-underline axis toggles rather than as one of
+   the pill-shaped filter buttons. `.controls button` is (0,1,1) and would beat
+   a bare `.axis-toggle` (0,1,0), so the compound selector below is required to
+   undo the pill styling. */
+.controls .similarity-toggle {
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+  border-bottom: 1.5px dashed var(--accent);
+  border-radius: 0;
+  padding: 0 0 1px;
+  cursor: pointer;
+}
+.controls .similarity-toggle:hover {
+  opacity: 0.7;
+  border-color: var(--accent);
 }
 
 /* Page load animation */

--- a/docs/ui.mjs
+++ b/docs/ui.mjs
@@ -8,6 +8,9 @@ import { predictStrengthCurve, predictStrengthMeanOnly, predictGWP, predictCost,
 import { stepPreviewComposition } from "./preview_state.mjs";
 import { makeComputedFilters, matchesFilters } from "./filters.mjs";
 import {
+  buildSimilarityContext, computeSimilarities, similarityToFillAlpha,
+} from "./similarity.mjs";
+import {
   UNITS,
   compToDisplay,
   compFromDisplay,
@@ -89,6 +92,11 @@ let curveObsPositions = []; // [{px, py, time, strength}] for tooltip hit-testin
 // end state used by click-to-edit while the interpolation is in flight.
 let compositionTransition = null; // {startComp, targetComp, startTime, duration}
 let scatterFilter = null; // [{colIdx, min, max}] array or null
+// Recipe-similarity encoding: fade catalog mixes by how unlike the currently
+// selected composition they are. In-memory only, like the unit and axis
+// toggles. `_similarityCache` mirrors the `_paretoCache` pattern below.
+let similarityEnabled = true;
+let _similarityCache = null; // { key, day, ctx, sims }
 let mixAnalyses = null; // pre-computed mix descriptions
 const CANVAS_CURVE = 1;
 const CANVAS_SCATTER = 2;
@@ -1904,6 +1912,31 @@ function getCachedParetoMask(xVals, yVals) {
   return mask;
 }
 
+// --- Cached Recipe Similarity ---
+// Similarity of every catalog mix to the *committed* composition. Deliberately
+// not the hover preview: re-centring on hover would churn the whole field every
+// time the cursor crossed a point.
+//
+// Cheap enough to recompute per frame (~11 µs for all 149 mixes), but the cache
+// avoids re-transforming the catalog, which is the expensive half.
+function getCachedSimilarities() {
+  if (!similarityEnabled || !strengthParams || !currentComposition || !compositionsData) {
+    return null;
+  }
+  const key = `${scatterDay}|${currentComposition.join(",")}`;
+  if (_similarityCache && _similarityCache.key === key) return _similarityCache.sims;
+  const ctx = _similarityCache && _similarityCache.day === scatterDay
+    ? _similarityCache.ctx
+    : buildSimilarityContext(compositionsData.compositions, strengthParams, scatterDay);
+  _similarityCache = {
+    key,
+    day: scatterDay,
+    ctx,
+    sims: computeSimilarities(currentComposition, ctx, strengthParams),
+  };
+  return _similarityCache.sims;
+}
+
 // --- Scatter Plot Transition Animation ---
 function getScatterData() {
   const df = getDisplayFactors();
@@ -2693,6 +2726,17 @@ function setupEventListeners() {
     toggleDay.textContent = dayLabels[nextIdx];
     startScatterTransition(() => { scatterDay = dayOptions[nextIdx]; });
     updateMixInsight();
+  });
+
+  // Recipe-similarity encoding toggle. Goes through invalidateCanvases rather
+  // than calling drawScatter() directly: canvas renderers must stay owned by
+  // requestAnimationFrame (asserted in test/e2e/canvas-frame-probe.ts).
+  const toggleSim = document.getElementById("toggle-similarity");
+  toggleSim.addEventListener("click", () => {
+    similarityEnabled = !similarityEnabled;
+    toggleSim.textContent = similarityEnabled ? "on" : "off";
+    toggleSim.setAttribute("aria-pressed", String(similarityEnabled));
+    invalidateCanvases(CANVAS_SCATTER);
   });
 
   // Filter panel — multi-dimensional filtering

--- a/docs/ui.mjs
+++ b/docs/ui.mjs
@@ -97,6 +97,14 @@ let scatterFilter = null; // [{colIdx, min, max}] array or null
 // toggles. `_similarityCache` mirrors the `_paretoCache` pattern below.
 let similarityEnabled = true;
 let _similarityCache = null; // { key, day, ctx, sims }
+// Per-draw scatter styling recorded only under ?test=1, so E2E can assert on the
+// rendering contract structurally instead of by fragile pixel comparison. Same
+// pattern as `curveDrawSequence` / `lastCurveRenderMode`; zero cost otherwise.
+const _testMode = typeof location !== "undefined" &&
+  new URLSearchParams(location.search).get("test") === "1";
+let _lastPointStyles = null;
+let _lastDrawOrder = null;
+let _lastLegend = null;
 let mixAnalyses = null; // pre-computed mix descriptions
 const CANVAS_CURVE = 1;
 const CANVAS_SCATTER = 2;
@@ -2110,30 +2118,70 @@ function drawScatter() {
   }
 
   // Draw points (apply filter if active)
+  //
+  // When the recipe-similarity encoding is on, each in-filter point's FILL is
+  // faded by how unlike the selected composition its recipe is, while its
+  // OUTLINE is drawn in the point's own hue at full opacity. Keeping the outline
+  // solid means position and contrast never degrade — a point can go hollow but
+  // never invisible, which a plain alpha fade cannot promise. Hue and radius are
+  // left entirely to the Pareto encoding.
+  const sims = getCachedSimilarities();
+  if (_testMode) _lastPointStyles = new Array(xVals.length);
+
+  // Filtered-out points are drawn first, in catalog order, so their rendering is
+  // byte-identical whether or not the encoding is on: exclusion is categorical
+  // and must never be confused with "far away".
+  const inFilter = [];
   for (let i = 0; i < xVals.length; i++) {
-    // Check all filter conditions
-    if (scatterFilter && scatterFilter.length > 0) {
-      const comp = compositionsData.compositions[i];
-      if (!matchesFilters(comp, scatterFilter)) {
-        const x = xScale(xVals[i]);
-        const y = yScale(yVals[i]);
-        ctx.beginPath();
-        ctx.arc(x, y, 1.5, 0, 2 * Math.PI);
-        ctx.fillStyle = "rgba(148, 163, 184, 0.3)";
-        ctx.fill();
-        continue;
-      }
+    if (scatterFilter && scatterFilter.length > 0 &&
+        !matchesFilters(compositionsData.compositions[i], scatterFilter)) {
+      ctx.beginPath();
+      ctx.arc(xScale(xVals[i]), yScale(yVals[i]), 1.5, 0, 2 * Math.PI);
+      ctx.fillStyle = "rgba(148, 163, 184, 0.3)";
+      ctx.fill();
+      if (_testMode) _lastPointStyles[i] = { kind: "filtered", fillAlpha: 0.3, stroke: null };
+      continue;
     }
+    inFilter.push(i);
+  }
+
+  // Least similar first, so the user's own neighbourhood ends up on top.
+  if (sims) inFilter.sort((a, b) => sims[a] - sims[b]);
+  if (_testMode) _lastDrawOrder = [...inFilter];
+
+  for (const i of inFilter) {
     const x = xScale(xVals[i]);
     const y = yScale(yVals[i]);
     const isPareto = paretoMask[i];
+    const base = isPareto ? clr.pareto : clr.point;
+
+    let fillAlpha = 1;
+    if (sims) {
+      const a = similarityToFillAlpha(sims[i]);
+      // Hovering means "I am interested in this one", so it renders at full
+      // emphasis. The previously hovered point eases back to its similarity
+      // alpha rather than snapping, which would flicker during the shrink-out.
+      if (i === hoveredPointIdx) fillAlpha = 1;
+      else if (i === prevHoveredPointIdx) fillAlpha = a + (1 - a) * prevHoverScale;
+      else fillAlpha = a;
+    }
+
     ctx.beginPath();
     ctx.arc(x, y, isPareto ? 5 : 3.5, 0, 2 * Math.PI);
-    ctx.fillStyle = isPareto ? clr.pareto : clr.point;
+    ctx.globalAlpha = fillAlpha;
+    ctx.fillStyle = base;
     ctx.fill();
-    ctx.strokeStyle = "rgba(255,255,255,0.7)";
-    ctx.lineWidth = 0.8;
+    ctx.globalAlpha = 1;
+    ctx.strokeStyle = sims ? base : "rgba(255,255,255,0.7)";
+    ctx.lineWidth = sims ? 1.2 : 0.8;
     ctx.stroke();
+    if (_testMode) {
+      _lastPointStyles[i] = {
+        kind: isPareto ? "pareto" : "dominated",
+        fillAlpha,
+        stroke: ctx.strokeStyle,
+      };
+    }
   }
 
   // Draw shrinking previous hovered point
@@ -2280,6 +2328,19 @@ function drawScatter() {
   ctx.textAlign = "center";
   ctx.fillText(`${scatterDay}-day Strength (${df.strength})`, 0, 0);
   ctx.restore();
+
+  // Tell the user what the fade means. Mirrors the "shaded: ±2σ" legend on the
+  // strength curve, including its textBaseline.
+  if (sims) {
+    ctx.save();
+    ctx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.textAlign = "right";
+    ctx.textBaseline = "top";
+    ctx.fillStyle = clr.text;
+    ctx.fillText("solid = similar recipe", W - pad.right, pad.top + 4);
+    ctx.restore();
+  }
+  if (_testMode) _lastLegend = sims ? "solid = similar recipe" : null;
 
   // Store scale functions for click handling
   canvas._xMin = xMin;
@@ -3104,6 +3165,18 @@ if (typeof location !== "undefined" &&
     // handler bails on a missing canvas scale stash, and a regression there
     // is invisible from the outside (no glow, and clicks silently do nothing).
     get hoveredPointIdx() { return hoveredPointIdx; },
+    // --- recipe-similarity encoding ---
+    get similarityEnabled() { return similarityEnabled; },
+    get similarities() {
+      const s = getCachedSimilarities();
+      return s ? Array.from(s) : null;
+    },
+    // Per-point styling recorded by the last drawScatter. Lets specs assert the
+    // rendering contract (fade, hue-carrying outline, filtered precedence)
+    // structurally rather than by comparing pixels.
+    get pointRenderStyles() { return _lastPointStyles ? [..._lastPointStyles] : null; },
+    get similarityDrawOrder() { return _lastDrawOrder ? [..._lastDrawOrder] : null; },
+    get scatterLegend() { return _lastLegend; },
     // True when the last draw put the preview curve on the same time grid as
     // the main curve. They are overlaid, so different grids make them
     // visibly disagree even when both are correct (a 32-pt main curve against

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,13 @@ import { defineConfig, devices } from "@playwright/test";
  * Each test runs once per project unless skipped via testInfo.project.name.
  *
  * See test/e2e/README.md for the catalogue of invariants.
+ *
+ * PORT: defaults to 4173, overridable via BOXCRETE_TEST_PORT. `reuseExistingServer`
+ * is on locally, so a server left running by another git worktree on the same
+ * port would silently be reused and the suite would test that checkout's docs/
+ * instead of this one's. Set BOXCRETE_TEST_PORT when running worktrees in parallel.
  */
+const PORT = Number(process.env.BOXCRETE_TEST_PORT ?? 4173);
 export default defineConfig({
   testDir: "./test/e2e",
   testMatch: /.*\.spec\.ts/,
@@ -29,7 +35,7 @@ export default defineConfig({
     : [["html", { open: "never" }], ["list"]],
 
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: `http://127.0.0.1:${PORT}`,
     // Capture diagnostics only on failure to keep artifacts small
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
@@ -59,8 +65,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: "npx http-server docs -p 4173 -s -c-1 -a 127.0.0.1",
-    url: "http://127.0.0.1:4173/index.html",
+    command: `npx http-server docs -p ${PORT} -s -c-1 -a 127.0.0.1`,
+    url: `http://127.0.0.1:${PORT}/index.html`,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
   },

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -66,6 +66,20 @@ property on a PR, add a spec for it before merging.
 | `visual-regression.spec.ts`   | Full-page screenshot matches committed Linux baseline (active on Linux)   | desktop+mobile |
 | `touch-targets.spec.ts`       | Slider hit area meets WCAG 2.2 AA (24 px) / Apple HIG (44 px mobile)      | desktop+mobile |
 | `mobile-behavior.spec.ts`     | Material Source tap commits an integral class; curve transition runs and clears; click-to-edit commits; curve non-blank | mobile |
+| `pareto-similarity.spec.ts`   | Similarity toggle defaults on, reports `aria-pressed`, and is keyboard operable | desktop |
+| `pareto-similarity.spec.ts`   | Enabled: distant recipes render faded and every outline carries the point hue; legend shown | desktop |
+| `pareto-similarity.spec.ts`   | Disabled: fills return to solid and the white outline; legend and similarities are null | desktop |
+| `pareto-similarity.spec.ts`   | Toggling is pixel-reversible under reduced motion, and on differs from off | desktop |
+| `pareto-similarity.spec.ts`   | Similarity tracks the selected composition and peaks at 1                 | desktop |
+| `pareto-similarity.spec.ts`   | Clicking a scatter point makes that exact mix maximally similar           | desktop |
+| `pareto-similarity.spec.ts`   | Hovering a faded point restores it to full emphasis                       | desktop |
+| `pareto-similarity.spec.ts`   | Points are drawn least-similar first, so neighbours land on top           | desktop |
+| `pareto-similarity.spec.ts`   | Filtered-out points keep grey styling and stay out of the similarity reorder | desktop |
+| `pareto-similarity.spec.ts`   | Similarity stays finite and in range across axis and curing-day changes   | desktop |
+| `pareto-similarity.spec.ts`   | The encoding works in both themes                                         | desktop |
+| `pareto-similarity.spec.ts`   | The scatter paints un-encoded before the model resolves (similarities null) | desktop |
+| `pareto-similarity.spec.ts`   | The toggle never draws outside requestAnimationFrame                      | desktop |
+| `pareto-similarity.spec.ts`   | Enabling similarity adds no scatter draws during a slider drag            | desktop |
 
 ## Running
 
@@ -88,6 +102,18 @@ npm run test:e2e:ui
 
 # show last HTML report
 npm run test:e2e:report
+```
+
+### Running several git worktrees at once
+
+The dev server is reused if one is already listening (`reuseExistingServer` is
+on outside CI), so a server left running by another checkout on the default port
+4173 is silently reused — and the suite then tests *that* checkout's `docs/`
+rather than this one's, which looks like inexplicable assertion failures. Give
+each worktree its own port:
+
+```bash
+BOXCRETE_TEST_PORT=4183 npm run test:e2e
 ```
 
 ## Updating visual snapshots

--- a/test/e2e/pareto-similarity.spec.ts
+++ b/test/e2e/pareto-similarity.spec.ts
@@ -1,0 +1,355 @@
+import { test, expect, Page } from "@playwright/test";
+import {
+  installCanvasFrameProbe,
+  resetCanvasFrameProbe,
+  snapshotCanvasFrames,
+  drawCount,
+  hoverRenderedScatterPoint,
+  waitForCanvasLoopToPark,
+} from "./canvas-frame-probe";
+
+/**
+ * Recipe-similarity encoding on the Pareto scatter plot.
+ *
+ * Each catalog point's FILL is faded by how unlike the currently selected
+ * composition its recipe is; its OUTLINE is drawn in the point's own hue at full
+ * opacity so position and contrast never degrade. Hue and radius remain the
+ * Pareto encoding.
+ *
+ * Assertions are made against `__test.pointRenderStyles` wherever possible.
+ * Pixel comparison is used only for the reversibility check, and only under
+ * reduced motion — the selected-composition ring pulses off `Date.now()`
+ * (ui.mjs), so the scatter canvas is otherwise time-dependent and no two draws
+ * are ever byte-identical.
+ */
+
+// The selected-composition ring pulses off Date.now() (ui.mjs), so the scatter
+// canvas is time-dependent unless reduced motion pins the pulse at mid-phase.
+// `_reduceMotion` is captured when ui.mjs is evaluated, so the emulation has to
+// be in place before goto(). `test.use({ reducedMotion })` does not reach the
+// page here, so each navigation calls emulateMedia explicitly.
+async function gotoWithReducedMotion(page: Page) {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/?test=1");
+}
+
+/** Canvas normalizes the legacy outline colour to this exact spacing. */
+const WHITE_OUTLINE = "rgba(255, 255, 255, 0.7)";
+
+async function ready(page: Page) {
+  await gotoWithReducedMotion(page);
+  await page.waitForFunction(
+    () => (window as any).__test?.modelReady === true,
+    null,
+    { timeout: 30000 },
+  );
+}
+
+const scatter = (page: Page) => page.locator("canvas#scatter-canvas");
+const toggle = (page: Page) => page.locator("#toggle-similarity");
+
+/** Styles of the points that are not filtered out. */
+function visibleStyles(page: Page) {
+  return page.evaluate(() =>
+    ((window as any).__test.pointRenderStyles || []).filter(
+      (s: any) => s && s.kind !== "filtered",
+    ),
+  );
+}
+
+test.describe("Pareto plot recipe-similarity encoding", () => {
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "scatter interaction is desktop");
+  });
+
+  // --- the control -----------------------------------------------------
+
+  test("toggle defaults to on and reports state via aria-pressed", async ({ page }) => {
+    await ready(page);
+    await expect(toggle(page)).toHaveAttribute("aria-pressed", "true");
+    await expect(toggle(page)).toHaveText("on");
+    await toggle(page).click();
+    await expect(toggle(page)).toHaveAttribute("aria-pressed", "false");
+    await expect(toggle(page)).toHaveText("off");
+  });
+
+  test("toggle is operable from the keyboard", async ({ page }) => {
+    await ready(page);
+    await toggle(page).focus();
+    await expect(toggle(page)).toBeFocused();
+    await page.keyboard.press("Enter");
+    await expect(toggle(page)).toHaveAttribute("aria-pressed", "false");
+    await page.keyboard.press("Space");
+    await expect(toggle(page)).toHaveAttribute("aria-pressed", "true");
+  });
+
+  // --- the rendering contract ------------------------------------------
+
+  test("on state fades distant mixes and gives the outline the point hue", async ({ page }) => {
+    await ready(page);
+    const styles = await visibleStyles(page);
+    expect(styles.length).toBeGreaterThan(0);
+    expect(
+      styles.some((s: any) => s.fillAlpha < 0.5),
+      "some mixes must render faded",
+    ).toBe(true);
+    expect(
+      styles.some((s: any) => s.fillAlpha > 0.95),
+      "the selected mix's neighbourhood must render solid",
+    ).toBe(true);
+    expect(
+      styles.every((s: any) => s.stroke !== WHITE_OUTLINE),
+      "the outline must carry the point hue, or hollow points vanish on light backgrounds",
+    ).toBe(true);
+    expect(await page.evaluate(() => (window as any).__test.scatterLegend)).toBe(
+      "solid = similar recipe",
+    );
+  });
+
+  test("off state restores the previous rendering contract exactly", async ({ page }) => {
+    await ready(page);
+    await toggle(page).click();
+    await expect
+      .poll(async () => {
+        const styles = await visibleStyles(page);
+        return (
+          styles.length > 0 &&
+          styles.every((s: any) => s.fillAlpha === 1 && s.stroke === WHITE_OUTLINE)
+        );
+      })
+      .toBe(true);
+    expect(await page.evaluate(() => (window as any).__test.scatterLegend)).toBeNull();
+    expect(await page.evaluate(() => (window as any).__test.similarities)).toBeNull();
+  });
+
+  test("toggling is pixel-reversible and on differs from off", async ({ page }) => {
+    await ready(page);
+
+    // The redraw is scheduled through requestAnimationFrame, so a screenshot
+    // taken straight after the click can still capture the previous mode.
+    async function flip() {
+      await toggle(page).click();
+      await waitForCanvasLoopToPark(page);
+      return scatter(page).screenshot();
+    }
+
+    const off1 = await flip();
+    const on1 = await flip();
+    const off2 = await flip();
+    const on2 = await flip();
+
+    expect(Buffer.compare(off1, off2), "off rendering must be reproducible").toBe(0);
+    expect(Buffer.compare(on1, on2), "on rendering must be reproducible").toBe(0);
+    expect(Buffer.compare(off1, on1), "on and off must look different").not.toBe(0);
+  });
+
+  // --- coupling to the composition --------------------------------------
+
+  test("similarity tracks the selected composition and peaks at 1", async ({ page }) => {
+    await ready(page);
+    const before = await page.evaluate(() => (window as any).__test.similarities);
+    expect(before.length).toBeGreaterThan(0);
+    expect(Math.max(...before)).toBeGreaterThan(0.99);
+    expect(Math.min(...before)).toBeGreaterThanOrEqual(0);
+
+    await page
+      .locator('#sliders input[type="range"]')
+      .first()
+      .evaluate((el: HTMLInputElement) => {
+        el.value = String(Number(el.max) * 0.85);
+        el.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+
+    await expect
+      .poll(async () =>
+        JSON.stringify(await page.evaluate(() => (window as any).__test.similarities)),
+      )
+      .not.toBe(JSON.stringify(before));
+  });
+
+  test("clicking a point makes that exact mix maximally similar", async ({ page }) => {
+    await ready(page);
+    await hoverRenderedScatterPoint(page);
+    const idx = await page.evaluate(() => (window as any).__test.hoveredPointIdx);
+    expect(idx, "hover helper must land on a point").not.toBeNull();
+    await page.mouse.down();
+    await page.mouse.up();
+    await expect
+      .poll(async () =>
+        page.evaluate((i) => (window as any).__test.similarities[i], idx),
+      )
+      .toBeGreaterThan(0.999);
+  });
+
+  test("hovering a faded point restores it to full emphasis", async ({ page }) => {
+    await ready(page);
+    await hoverRenderedScatterPoint(page);
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const t = (window as any).__test;
+          if (t.hoveredPointIdx === null) return null;
+          return t.pointRenderStyles[t.hoveredPointIdx].fillAlpha;
+        }),
+      )
+      .toBe(1);
+  });
+
+  // --- interaction with the other encodings ------------------------------
+
+  test("points are drawn least-similar first", async ({ page }) => {
+    await ready(page);
+    const { order, sims } = await page.evaluate(() => ({
+      order: (window as any).__test.similarityDrawOrder,
+      sims: (window as any).__test.similarities,
+    }));
+    expect(order.length).toBeGreaterThan(1);
+    for (let k = 1; k < order.length; k++) {
+      expect(
+        sims[order[k]],
+        "draw order must be ascending in similarity so neighbours land on top",
+      ).toBeGreaterThanOrEqual(sims[order[k - 1]]);
+    }
+  });
+
+  test("filtered-out points keep grey styling and stay out of the reorder", async ({ page }) => {
+    await ready(page);
+    await page.locator("#filter-add").click();
+    // Selecting a column alone filters nothing; a range is what excludes points.
+    const row = page.locator("#filter-rows .filter-row").first();
+    await row.locator(".filter-col").selectOption("0"); // Cement
+    const maxInput = row.locator(".filter-max");
+    await expect(maxInput).toBeVisible();
+    // The filter inputs listen on "change", not "input".
+    await maxInput.fill("200");
+    await maxInput.dispatchEvent("change");
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const t = (window as any).__test;
+          const styles = t.pointRenderStyles || [];
+          const filtered = styles
+            .map((s: any, i: number) => (s && s.kind === "filtered" ? i : -1))
+            .filter((i: number) => i >= 0);
+          // Sentinel rather than `true`, so a filter that excludes nothing fails
+          // loudly instead of passing vacuously.
+          if (filtered.length === 0) return "no-filtered-points";
+          const allGrey = filtered.every((i: number) => styles[i].fillAlpha === 0.3);
+          const excluded = filtered.every(
+            (i: number) => !t.similarityDrawOrder.includes(i),
+          );
+          return allGrey && excluded;
+        }),
+      )
+      .toBe(true);
+  });
+
+  test("similarity survives axis and curing-day changes", async ({ page }) => {
+    await ready(page);
+    for (const id of ["#toggle-x", "#toggle-day"]) {
+      await page.locator(id).click();
+      await expect
+        .poll(async () =>
+          page.evaluate(() => {
+            const s = (window as any).__test.similarities;
+            return (
+              s !== null &&
+              s.length > 0 &&
+              s.every((v: number) => Number.isFinite(v) && v >= 0 && v <= 1)
+            );
+          }),
+        )
+        .toBe(true);
+    }
+  });
+
+  test("the encoding works in dark and light themes", async ({ page }) => {
+    await ready(page);
+    await page.locator("#theme-toggle").click();
+    await expect
+      .poll(async () => (await visibleStyles(page)).some((s: any) => s.fillAlpha < 0.5))
+      .toBe(true);
+    const on = await scatter(page).screenshot();
+    await toggle(page).click();
+    expect(Buffer.compare(on, await scatter(page).screenshot())).not.toBe(0);
+  });
+
+  // --- robustness --------------------------------------------------------
+
+  test("the scatter renders un-encoded before the model resolves", async ({ page }) => {
+    // Stall the worker so the pre-model window is wide enough to observe.
+    await page.route("**/model_init_worker.mjs", async (route) => {
+      await new Promise((r) => setTimeout(r, 4000));
+      await route.continue();
+    });
+    await gotoWithReducedMotion(page);
+    await page.waitForFunction(() => typeof (window as any).__test !== "undefined");
+    await page.locator("#sliders input[type=range]").first().waitFor({ timeout: 15000 });
+
+    const pre = await page.evaluate(() => ({
+      modelReady: (window as any).__test.modelReady,
+      sims: (window as any).__test.similarities,
+    }));
+    expect(
+      pre.modelReady,
+      "test needs the pre-model window; worker resolved too fast",
+    ).toBe(false);
+    expect(pre.sims, "similarities must be null before the model lands").toBeNull();
+
+    const painted = await scatter(page).evaluate((c: HTMLCanvasElement) => {
+      const d = c.getContext("2d")!.getImageData(0, 0, c.width, c.height).data;
+      for (let i = 3; i < d.length; i += 400) if (d[i] !== 0) return true;
+      return false;
+    });
+    expect(painted, "scatter must still paint before the model resolves").toBe(true);
+  });
+
+  // --- scheduling and cost ------------------------------------------------
+
+  test("the toggle does not draw outside requestAnimationFrame", async ({ page }) => {
+    await installCanvasFrameProbe(page);
+    await ready(page);
+    await resetCanvasFrameProbe(page);
+    await toggle(page).click();
+    await expect
+      .poll(async () => drawCount(await snapshotCanvasFrames(page), "scatter"))
+      .toBeGreaterThan(0);
+    const snap = await snapshotCanvasFrames(page);
+    expect(
+      snap.events.filter((event) => event.phase === "sync"),
+      "canvas renderers must be owned by requestAnimationFrame",
+    ).toHaveLength(0);
+  });
+
+  test("enabling similarity does not add scatter draws", async ({ page }) => {
+    await installCanvasFrameProbe(page);
+    await ready(page);
+
+    async function drawsForTenSliderSteps() {
+      await resetCanvasFrameProbe(page);
+      const slider = page.locator('#sliders input[type="range"]').first();
+      for (let k = 0; k < 10; k++) {
+        await slider.evaluate((el: HTMLInputElement, step: number) => {
+          el.value = String(Number(el.max) * (0.3 + step * 0.05));
+          el.dispatchEvent(new Event("input", { bubbles: true }));
+        }, k);
+      }
+      await expect
+        .poll(async () => drawCount(await snapshotCanvasFrames(page), "scatter"))
+        .toBeGreaterThan(0);
+      return drawCount(await snapshotCanvasFrames(page), "scatter");
+    }
+
+    const withOn = await drawsForTenSliderSteps();
+    await toggle(page).click(); // off
+    const withOff = await drawsForTenSliderSteps();
+
+    expect(withOn, "the probe must observe draws in both modes").toBeGreaterThan(0);
+    expect(withOff, "the probe must observe draws in both modes").toBeGreaterThan(0);
+    expect(
+      withOn,
+      "similarity must not increase the scatter draw count",
+    ).toBeLessThanOrEqual(withOff + 2);
+  });
+});

--- a/test/test_js_similarity.mjs
+++ b/test/test_js_similarity.mjs
@@ -116,6 +116,32 @@ check(
 
 check("null params yields null", compositionSimilarity(X[0], X[1], null, 28) === null);
 
+// --- parity with the production kernel -------------------------------------
+// Our composition-only similarity must reconstruct gp.mjs's full normalized
+// kernel exactly once the (constant, at equal curing day) time branch is added
+// back. This is what stops similarity.mjs drifting into a private, divergent
+// reimplementation of the model. If it ever fails, fix similarity.mjs, not this.
+let worstParity = 0;
+for (const [i, j] of [
+  [0, 1],
+  [5, 40],
+  [12, 12],
+  [100, 3],
+  [77, 148],
+]) {
+  const z1 = transformInput([...X[i], 28], P);
+  const z2 = transformInput([...X[j], 28], P);
+  const full = kernel(z1, z2, P) / Math.sqrt(kernel(z1, z1, P) * kernel(z2, z2, P));
+  const s = compositionSimilarity(X[i], X[j], P, 28);
+  const reconstructed = (s * (osB + osS) + osT) / (osB + osS + osT);
+  worstParity = Math.max(worstParity, Math.abs(full - reconstructed));
+}
+check(
+  "similarity reconstructs gp.mjs kernel() exactly",
+  worstParity < 1e-10,
+  `max err ${worstParity}`,
+);
+
 // ===== INSERT NEW CHECKS ABOVE THIS LINE — the exit gate must stay last =====
 if (failures) {
   console.error(`\n${failures} failure(s)`);

--- a/test/test_js_similarity.mjs
+++ b/test/test_js_similarity.mjs
@@ -16,6 +16,7 @@ import { readFileSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { matern52ActiveDims, kernel, transformInput } from "../docs/gp.mjs";
+import { compositionSimilarity } from "../docs/similarity.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const modelDir = resolve(__dirname, "..", "docs", "model");
@@ -42,6 +43,78 @@ check("kernel is exported", typeof kernel === "function");
 check("transformInput is exported", typeof transformInput === "function");
 check("catalog has compositions", Array.isArray(X) && X.length > 0);
 check("outputscales are present", osB > 0 && osS > 0 && osT > 0);
+
+// --- core metric -----------------------------------------------------------
+check("s(x,x) === 1", close(compositionSimilarity(X[0], X[0], P, 28), 1, 1e-12));
+check(
+  "symmetry",
+  close(
+    compositionSimilarity(X[3], X[9], P, 28),
+    compositionSimilarity(X[9], X[3], P, 28),
+    1e-12,
+  ),
+);
+
+let minS = Infinity;
+let maxS = -Infinity;
+let bad = 0;
+for (let i = 0; i < X.length; i++) {
+  for (let j = 0; j < X.length; j++) {
+    const s = compositionSimilarity(X[i], X[j], P, 28);
+    if (!Number.isFinite(s) || s < 0 || s > 1 + 1e-12) bad++;
+    if (s < minS) minS = s;
+    if (s > maxS) maxS = s;
+  }
+}
+check("all 149x149 similarities finite and in [0,1]", bad === 0, `${bad} bad`);
+
+// GUARD: with RBF_time wrongly folded in, the floor is 0.907 rather than 0.267.
+check("dynamic range is usable (min < 0.40)", minS < 0.4, `min=${minS.toFixed(4)}`);
+check("max similarity is 1", close(maxS, 1, 1e-12));
+
+// The source dim is categorical: the model uses a Hamming kernel for it, so a
+// 0->2 class change must be exactly as dissimilar as 0->1, never "twice as far".
+const b0 = [...X[0]];
+const b1 = [...X[0]];
+const b2 = [...X[0]];
+b0[SRC] = 0;
+b1[SRC] = 1;
+b2[SRC] = 2;
+check(
+  "source 0->1 equals 0->2 (Hamming, not ordinal)",
+  close(
+    compositionSimilarity(b0, b1, P, 28),
+    compositionSimilarity(b0, b2, P, 28),
+    1e-12,
+  ),
+);
+const expectedCross =
+  (osB + osS * P.matern_specific.source_correlation) / (osB + osS);
+check(
+  "cross-class similarity uses the learned source_correlation",
+  close(compositionSimilarity(b0, b1, P, 28), expectedCross, 1e-10),
+);
+
+let prev = 1.0;
+let mono = true;
+for (const d of [10, 50, 120, 300]) {
+  const p = [...X[0]];
+  p[0] += d; // dim 0 = Cement
+  const s = compositionSimilarity(X[0], p, P, 28);
+  if (!(s < prev)) mono = false;
+  prev = s;
+}
+check("similarity strictly decreases with a growing perturbation", mono);
+
+// Temp (raw dim 8) is part of the metric -- an explicit product requirement.
+const tempShift = [...X[0]];
+tempShift[8] += 15;
+check(
+  "Temp contributes to the distance",
+  compositionSimilarity(X[0], tempShift, P, 28) < 1 - 1e-6,
+);
+
+check("null params yields null", compositionSimilarity(X[0], X[1], null, 28) === null);
 
 // ===== INSERT NEW CHECKS ABOVE THIS LINE — the exit gate must stay last =====
 if (failures) {

--- a/test/test_js_similarity.mjs
+++ b/test/test_js_similarity.mjs
@@ -16,7 +16,12 @@ import { readFileSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { matern52ActiveDims, kernel, transformInput } from "../docs/gp.mjs";
-import { compositionSimilarity } from "../docs/similarity.mjs";
+import {
+  compositionSimilarity,
+  similarityToFillAlpha,
+  SIMILARITY_FLOOR,
+  FILL_ALPHA_MIN,
+} from "../docs/similarity.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const modelDir = resolve(__dirname, "..", "docs", "model");
@@ -140,6 +145,42 @@ check(
   "similarity reconstructs gp.mjs kernel() exactly",
   worstParity < 1e-10,
   `max err ${worstParity}`,
+);
+
+// --- contrast stretch ------------------------------------------------------
+check("alpha(1) === 1", close(similarityToFillAlpha(1), 1, 1e-12));
+check(
+  "alpha at/below the floor === FILL_ALPHA_MIN",
+  close(similarityToFillAlpha(SIMILARITY_FLOOR), FILL_ALPHA_MIN, 1e-12) &&
+    close(similarityToFillAlpha(0), FILL_ALPHA_MIN, 1e-12),
+);
+check("alpha is never zero (the point stays visible)", similarityToFillAlpha(0) > 0);
+
+let alphaMonotone = true;
+let lastAlpha = -1;
+for (let s = 0; s <= 1.0001; s += 0.02) {
+  const a = similarityToFillAlpha(s);
+  if (a < lastAlpha - 1e-12 || a < 0 || a > 1) alphaMonotone = false;
+  lastAlpha = a;
+}
+check("alpha is monotone non-decreasing within [0,1]", alphaMonotone);
+check(
+  "out-of-range inputs clamp rather than produce NaN",
+  similarityToFillAlpha(-5) === FILL_ALPHA_MIN &&
+    close(similarityToFillAlpha(9), 1, 1e-12),
+);
+check("NaN degrades to the floor", similarityToFillAlpha(NaN) === FILL_ALPHA_MIN);
+
+// The stretch exists to create contrast: raw similarities sit in a narrow IQR
+// of roughly [0.64, 0.83], which would render as a uniformly ~70% solid plot.
+const frameAlphas = X.map((c) =>
+  similarityToFillAlpha(compositionSimilarity(X[0], c, P, 28)),
+);
+const alphaSpread = Math.max(...frameAlphas) - Math.min(...frameAlphas);
+check(
+  "rendered alpha spread across a frame exceeds 0.5",
+  alphaSpread > 0.5,
+  `spread=${alphaSpread.toFixed(3)}`,
 );
 
 // ===== INSERT NEW CHECKS ABOVE THIS LINE — the exit gate must stay last =====

--- a/test/test_js_similarity.mjs
+++ b/test/test_js_similarity.mjs
@@ -1,0 +1,51 @@
+/**
+ * Recipe-similarity metric checks.
+ *
+ * Similarity between two mixes is the strength GP's own normalized composition
+ * kernel — the model's believed correlation between them. Two of the checks
+ * below are load-bearing anti-regression guards:
+ *
+ *   - the DYNAMIC RANGE check fails if the RBF_time branch is ever folded back
+ *     into the metric. At equal curing day it contributes a constant 0.4578 of
+ *     the 0.5245 total outputscale, which silently compresses every similarity
+ *     into [0.907, 1.0] and makes the encoding look uniform rather than broken.
+ *   - the KERNEL PARITY check fails if docs/similarity.mjs drifts from the
+ *     production kernel in docs/gp.mjs.
+ */
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { matern52ActiveDims, kernel, transformInput } from "../docs/gp.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const modelDir = resolve(__dirname, "..", "docs", "model");
+const P = JSON.parse(readFileSync(resolve(modelDir, "strength.json"), "utf-8"));
+const C = JSON.parse(readFileSync(resolve(modelDir, "compositions.json"), "utf-8"));
+const X = C.compositions;
+const SRC = P.source_dim_raw; // 7
+const osB = P.matern_blind.outputscale;
+const osS = P.matern_specific.outputscale;
+const osT = P.rbf_time.outputscale;
+
+let failures = 0;
+function check(name, cond, detail = "") {
+  if (cond) console.log(`  ok   ${name}`);
+  else {
+    console.error(`  FAIL ${name}${detail ? " — " + detail : ""}`);
+    failures++;
+  }
+}
+const close = (a, b, tol = 1e-9) => Math.abs(a - b) <= tol;
+
+check("matern52ActiveDims is exported", typeof matern52ActiveDims === "function");
+check("kernel is exported", typeof kernel === "function");
+check("transformInput is exported", typeof transformInput === "function");
+check("catalog has compositions", Array.isArray(X) && X.length > 0);
+check("outputscales are present", osB > 0 && osS > 0 && osT > 0);
+
+// ===== INSERT NEW CHECKS ABOVE THIS LINE — the exit gate must stay last =====
+if (failures) {
+  console.error(`\n${failures} failure(s)`);
+  process.exit(1);
+}
+console.log("\nAll similarity tests passed.");

--- a/test/test_js_similarity.mjs
+++ b/test/test_js_similarity.mjs
@@ -19,6 +19,8 @@ import { matern52ActiveDims, kernel, transformInput } from "../docs/gp.mjs";
 import {
   compositionSimilarity,
   similarityToFillAlpha,
+  buildSimilarityContext,
+  computeSimilarities,
   SIMILARITY_FLOOR,
   FILL_ALPHA_MIN,
 } from "../docs/similarity.mjs";
@@ -181,6 +183,47 @@ check(
   "rendered alpha spread across a frame exceeds 0.5",
   alphaSpread > 0.5,
   `spread=${alphaSpread.toFixed(3)}`,
+);
+
+// --- batched path ----------------------------------------------------------
+const ctx = buildSimilarityContext(X, P, 28);
+const sims = computeSimilarities(X[0], ctx, P);
+check("one similarity per catalog mix", sims.length === X.length);
+check(
+  "batched agrees with pairwise",
+  X.every((c, i) => close(sims[i], compositionSimilarity(X[0], c, P, 28), 1e-12)),
+);
+check("self-similarity is 1 at the reference index", close(sims[0], 1, 1e-12));
+check("null params yields null (pre-model)", computeSimilarities(X[0], ctx, null) === null);
+check("null context yields null", computeSimilarities(X[0], null, P) === null);
+check(
+  "empty catalog yields an empty result",
+  computeSimilarities(X[0], buildSimilarityContext([], P, 28), P).length === 0,
+);
+const simsAgain = computeSimilarities(X[0], ctx, P);
+check("deterministic across calls", sims.every((v, i) => v === simsAgain[i]));
+
+// A dragged slider puts the reference between catalog points, so the reference
+// is routinely off-catalog. That path must stay finite and in range.
+const offCatalog = X[0].map((v, i) => (i === SRC ? v : v * 1.37 + 5));
+check(
+  "off-catalog reference stays finite and in range",
+  computeSimilarities(offCatalog, ctx, P).every(
+    (v) => Number.isFinite(v) && v >= 0 && v <= 1 + 1e-12,
+  ),
+);
+
+// --- golden fixture --------------------------------------------------------
+// Pins behaviour against the shipped model artifact. Regenerate DELIBERATELY,
+// and review the diff, if the strength model is ever retrained.
+const GOLDEN_TOP5 = [0, 16, 22, 19, 15];
+const top5 = Array.from(sims.keys())
+  .sort((i, j) => sims[j] - sims[i])
+  .slice(0, 5);
+check(
+  "golden: top-5 nearest neighbours of catalog mix #0 are unchanged",
+  JSON.stringify(top5) === JSON.stringify(GOLDEN_TOP5),
+  `got [${top5}], want [${GOLDEN_TOP5}]`,
 );
 
 // ===== INSERT NEW CHECKS ABOVE THIS LINE — the exit gate must stay last =====


### PR DESCRIPTION
Draft. Full rationale: [`docs/design/pareto-similarity.md`](https://github.com/facebookresearch/SustainableConcrete/blob/feature/pareto-similarity-encoding/docs/design/pareto-similarity.md).

## What this does

In the Pareto scatter, two points sitting next to each other may be chemically unrelated mixes that merely land in the same place — so a user holding a composition cannot tell which nearby frontier mixes are **realistic substitutions**.

This fades each point's **fill** by how unlike the selected recipe it is, while keeping the **outline** at full opacity in the point's own hue. Hue and radius keep their existing Pareto meaning. A toggle in the scatter control strip turns it off; it defaults on.

## Key decisions

- **The metric is the production GP's own kernel**, normalized to a correlation in [0,1] — not a hand-rolled distance. Its ARD lengthscales are *learned*, so it already knows Temp matters less than Cement, and it treats Material Source as an unordered categorical. A Euclidean metric would need hand-chosen weights and would wrongly make source `0→2` twice as far as `0→1`.
- **The time branch is excluded.** Two mixes are always compared at the same curing day, so `RBF_time` collapses to a constant 0.4578 of the 0.5245 total. Folding it in compresses every similarity into `[0.907, 1.0]` — a *uniform* plot rather than an obviously broken one. A test asserts `min < 0.40` to catch exactly that.
- **Contrast stretch, because raw similarities are too clustered.** They span `[0.267, 1.0]` but with an IQR of only `[0.637, 0.828]`; mapped straight to alpha, every point renders ~70% solid, i.e. no visible encoding. `alpha = 0.06 + 0.94·t²` after a floor-shift at 0.25 spreads a frame across ~`[0.18, 0.95]`. A test asserts the rendered spread exceeds 0.5 — that is the real guard on the constant.
- **Outline stays solid**, so a point can go hollow but never invisible; position and contrast never degrade.
- **Two-level cache** — the transformed catalog is retained across composition changes and rebuilt only on a curing-day change, so a slider drag runs 149 kernel evals and zero input transforms (~11 µs).

## Also included: `BOXCRETE_TEST_PORT`

Makes the Playwright port overridable (default 4173). Without it, running e2e in two git worktrees at once **silently tests the wrong checkout** — `reuseExistingServer` is on locally, so another worktree's server gets reused. Presents as inexplicable failures. Worth landing regardless of the rest.

## Verification

macOS arm64 at `02b1a2b`, sequential with `CI=1`. Head is `0117c05`, which adds only a markdown design doc.

| Check | Result |
|---|---|
| `make lint` | PASS |
| `make test-js` | PASS — 14/14 |
| `make test-py` | PASS — 270 passed |
| e2e desktop+mobile | **PASS — 168 passed** |

## What's left

- Rebase onto `main` (forked at `18d9792`); conflicts expected in `Makefile`, `docs/index.html`, `docs/style.css`, `docs/ui.mjs`, `playwright.config.ts`.
- The e2e spec is `desktop`-only, so the encoding is unverified on WebKit.
- The metric is coupled to the shipped model artifact: retraining the strength GP changes similarities and the golden neighbour list. A kernel-parity test (< 1e-10) stops `similarity.mjs` and `gp.mjs` drifting apart.