### PR TITLE
[WIP] Strength curve continuous hover tooltip

### DIFF
--- a/docs/ui.mjs
+++ b/docs/ui.mjs
@@ -45,6 +45,17 @@ let currentComposition = null; // current slider values (without time)
 let scatterDay = 28;
 let scatterXAxis = "gwp"; // "gwp" or "cost"
 let curveObsPositions = []; // [{px, py, time, strength}] for tooltip hit-testing
+// Strength-curve continuous hover state. When the user hovers (or taps) the
+// curve canvas at a point that's NOT an observation, we show a vertical
+// guide + dot at the cursor and a tooltip with the predicted strength at
+// that time. Cleared on pointer-leave / pointer-up. Coexists with
+// `hoveredCurveObsIdx`: if an observation is under the cursor, that's
+// shown instead (observation tooltip has its own format).
+let _curveHover = null; // {canvasX} — cursor position in canvas-local CSS px, or null
+// Geometry of the most recent `drawStrengthCurve` frame, cached so the
+// pointer handler can interpolate predictions at the cursor's x without
+// re-running the GP. Updated every draw, read by `readCurveAt`.
+let _lastCurveGeom = null; // {pad, W, H, times, means, stds, sf}
 let animationId = null; // for smooth transitions
 // Most recent animation TARGET (intended end state). When the user commits a
 // click-to-edit value during an in-flight animation, we build the new target
@@ -938,6 +949,49 @@ function hideExtrapolationWarning() {
   if (warningEl) warningEl.classList.remove("visible");
 }
 
+// Linear interpolate `(mean, std)` at curing time `t` (days) from the curve's
+// log-spaced sample arrays. Used by the continuous-hover indicator and tooltip.
+function interpolateCurveAtTime(t, times, means, stds) {
+  const n = times.length;
+  if (n === 0) return null;
+  if (t <= times[0]) return { mean: means[0], std: stds[0] };
+  if (t >= times[n - 1]) return { mean: means[n - 1], std: stds[n - 1] };
+  // Linear scan (n is 32–64, not worth a binary search)
+  let lo = 0;
+  for (let i = 1; i < n; i++) {
+    if (times[i] >= t) { lo = i - 1; break; }
+  }
+  const t0 = times[lo], t1 = times[lo + 1];
+  const frac = t1 > t0 ? (t - t0) / (t1 - t0) : 0;
+  return {
+    mean: means[lo] + (means[lo + 1] - means[lo]) * frac,
+    std: stds[lo] + (stds[lo + 1] - stds[lo]) * frac,
+  };
+}
+
+// Read the curve's predicted (time, mean, std) at a given canvas-local x.
+// Returns `null` if the cache is empty (page hasn't drawn yet) or the x is
+// outside the plot area's horizontal padding.
+function readCurveAt(canvasX) {
+  if (!_lastCurveGeom) return null;
+  const { pad, W, times, means, stds } = _lastCurveGeom;
+  if (canvasX < pad.left || canvasX > W - pad.right) return null;
+  const t = (canvasX - pad.left) / (W - pad.left - pad.right) * 28;
+  const interp = interpolateCurveAtTime(t, times, means, stds);
+  if (!interp) return null;
+  return { time: t, meanRaw: interp.mean, stdRaw: interp.std };
+}
+
+// Format a strength value for the tooltip in the active unit.
+//  - psi (large): rounded, locale-grouped (e.g., 8,240).
+//  - MPa (small): one decimal (e.g., 56.7).
+function formatStrengthForTooltip(rawValue, df) {
+  const display = Math.max(0, rawValue * df.strengthFactor);
+  return display < 10
+    ? display.toFixed(1)
+    : Math.round(display).toLocaleString();
+}
+
 // --- Strength Curve Canvas ---
 function drawStrengthCurve() {
   const canvas = document.getElementById("curve-canvas");
@@ -1096,6 +1150,46 @@ function drawStrengthCurve() {
       ctx.globalAlpha = 1;
     }
   }
+
+  // === Continuous-curve hover indicator ===
+  // When `_curveHover` is set and the cursor isn't already over an observation
+  // point (which has its own affordance), draw a vertical dashed guide + a
+  // dot at the predicted mean. The tooltip text is computed independently in
+  // the pointer handler via `readCurveAt(...)`.
+  if (_curveHover !== null && hoveredCurveObsIdx === null) {
+    const cx = _curveHover.canvasX;
+    if (cx >= pad.left && cx <= W - pad.right) {
+      const t = (cx - pad.left) / (W - pad.left - pad.right) * 28;
+      const interp = interpolateCurveAtTime(t, times, means, stds);
+      if (interp) {
+        const dotY = yScale(Math.max(0, interp.mean * sf));
+        // Vertical dashed guide spanning the plot area
+        ctx.save();
+        ctx.setLineDash([4, 4]);
+        ctx.strokeStyle = colors.text;
+        ctx.globalAlpha = 0.4;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(cx, pad.top);
+        ctx.lineTo(cx, H - pad.bottom);
+        ctx.stroke();
+        ctx.restore();
+        // Dot at the predicted mean (visually distinct from the orange
+        // observation dots: uses --accent + a thicker white border)
+        ctx.beginPath();
+        ctx.arc(cx, dotY, 5, 0, 2 * Math.PI);
+        ctx.fillStyle = colors.accent;
+        ctx.fill();
+        ctx.strokeStyle = "rgba(255,255,255,0.9)";
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+    }
+  }
+
+  // Cache the geometry so the pointer handler in `setupEventListeners` can
+  // interpolate predictions at the cursor's x without re-running the GP.
+  _lastCurveGeom = { pad, W, H, times, means, stds, sf };
 
   // Axes
   ctx.strokeStyle = colors.axis;
@@ -1864,59 +1958,119 @@ function setupEventListeners() {
     }
   });
 
-  // Tooltip on strength curve canvas for observed data points
+  // Tooltip on strength curve canvas.
+  //
+  // Two hover modes share the same DOM tooltip element:
+  //   (1) cursor over a real observation point — "Day N: <strength> <unit>"
+  //   (2) cursor anywhere else on the plot — "Day X.X · <mean> <unit> (±<std>)"
+  // Mode (1) takes priority via observation hit-test inside `_obsHitTest`.
+  // Pointer events (rather than mouse events) cover both desktop mouse and
+  // mobile touch input.
   const curveCanvas = document.getElementById("curve-canvas");
   const tooltip = document.createElement("div");
   tooltip.className = "tooltip";
   tooltip.style.display = "none";
   document.body.appendChild(tooltip);
 
-  curveCanvas.addEventListener("mousemove", (e) => {
+  function _obsHitTest(mx, my) {
+    for (const pt of curveObsPositions) {
+      const dx = mx - pt.px;
+      const dy = my - pt.py;
+      if (dx * dx + dy * dy < 100) return pt; // 10 px radius
+    }
+    return null;
+  }
+
+  function handleCurvePointer(e) {
     const rect = curveCanvas.getBoundingClientRect();
     const mx = e.clientX - rect.left;
     const my = e.clientY - rect.top;
 
-    // Check if cursor is near any observation point
-    let hit = null;
-    let hitIdx = null;
-    for (const pt of curveObsPositions) {
-      const dx = mx - pt.px;
-      const dy = my - pt.py;
-      if (dx * dx + dy * dy < 100) { // within 10px radius
-        hit = pt;
-        hitIdx = pt.idx;
-        break;
-      }
-    }
-
-    // Update hover state for animation
-    if (hitIdx !== hoveredCurveObsIdx) {
-      hoveredCurveObsIdx = hitIdx;
+    // (1) Observation hit-test takes priority.
+    const obsHit = _obsHitTest(mx, my);
+    const obsIdx = obsHit ? obsHit.idx : null;
+    if (obsIdx !== hoveredCurveObsIdx) {
+      hoveredCurveObsIdx = obsIdx;
       curveObsHoverScale = 0;
       startAnimLoop();
     }
 
-    if (hit) {
-      const dispStrength = (hit.strength * U().strengthFactor);
-      const unit = U().strength;
-      tooltip.textContent = `Day ${hit.time}: ${dispStrength < 10 ? dispStrength.toFixed(1) : Math.round(dispStrength).toLocaleString()} ${unit}`;
+    if (obsHit) {
+      const df = U();
+      const value = formatStrengthForTooltip(obsHit.strength, df);
+      tooltip.textContent = `Day ${obsHit.time}: ${value} ${df.strength}`;
       tooltip.style.display = "block";
       tooltip.style.left = `${e.clientX + 12}px`;
       tooltip.style.top = `${e.clientY - 28}px`;
       curveCanvas.style.cursor = "pointer";
+      // Continuous-curve indicator suppressed while hovering an observation.
+      if (_curveHover !== null) {
+        _curveHover = null;
+        startAnimLoop();
+      }
+      return;
+    }
+
+    // (2) Continuous-curve hover — read predicted (mean, ±std) at the cursor's
+    //     time projection.
+    const reading = readCurveAt(mx);
+    if (reading) {
+      const df = U();
+      const meanFmt = formatStrengthForTooltip(reading.meanRaw, df);
+      const stdFmt = formatStrengthForTooltip(reading.stdRaw, df);
+      tooltip.textContent = `Day ${reading.time.toFixed(1)} · ${meanFmt} ${df.strength} (±${stdFmt})`;
+      tooltip.style.display = "block";
+      tooltip.style.left = `${e.clientX + 12}px`;
+      tooltip.style.top = `${e.clientY - 28}px`;
+      curveCanvas.style.cursor = "crosshair";
+      _curveHover = { canvasX: mx };
+      startAnimLoop();
     } else {
       tooltip.style.display = "none";
       curveCanvas.style.cursor = "default";
+      if (_curveHover !== null) {
+        _curveHover = null;
+        startAnimLoop();
+      }
     }
-  });
+  }
 
-  curveCanvas.addEventListener("mouseleave", () => {
+  function handleCurvePointerLeave(e) {
+    // For touch input the OS fires pointerleave / pointercancel right after
+    // every tap — hiding the tooltip there would erase the value the user
+    // just tapped to read. We only hide on mouse-driven leaves; touch
+    // tooltips are dismissed by the document-level outside-tap handler
+    // installed below.
+    if (e && e.pointerType === "touch") return;
     tooltip.style.display = "none";
     curveCanvas.style.cursor = "default";
     if (hoveredCurveObsIdx !== null) {
       hoveredCurveObsIdx = null;
       startAnimLoop();
     }
+    if (_curveHover !== null) {
+      _curveHover = null;
+      startAnimLoop();
+    }
+  }
+
+  // `pointerdown` covers brief touch taps where `pointermove` may not fire;
+  // `pointermove` covers mouse movement and touch dragging.
+  curveCanvas.addEventListener("pointerdown", handleCurvePointer);
+  curveCanvas.addEventListener("pointermove", handleCurvePointer);
+  curveCanvas.addEventListener("pointerleave", handleCurvePointerLeave);
+  curveCanvas.addEventListener("pointercancel", handleCurvePointerLeave);
+
+  // Touch dismiss: tap anywhere off the curve canvas hides the persistent
+  // tooltip and clears the indicator. Mouse users get the same effect via
+  // `pointerleave`; this handler only matters for touch.
+  document.addEventListener("pointerdown", (e) => {
+    if (e.pointerType !== "touch") return;
+    if (curveCanvas.contains(e.target)) return;
+    if (tooltip.style.display === "none" && _curveHover === null && hoveredCurveObsIdx === null) return;
+    tooltip.style.display = "none";
+    if (_curveHover !== null) { _curveHover = null; startAnimLoop(); }
+    if (hoveredCurveObsIdx !== null) { hoveredCurveObsIdx = null; startAnimLoop(); }
   });
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -11,6 +11,12 @@ property on a PR, add a spec for it before merging.
 |-------------------------------|---------------------------------------------------------------------------|------------|
 | `home-loads.spec.ts`          | Home page loads with no console/page errors and core canvases visible     | desktop+mobile |
 | `home-loads.spec.ts`          | Strength curve canvas renders within a few seconds of load                | desktop+mobile |
+| `curve-hover.spec.ts`         | Hovering inside the strength-curve plot shows continuous tooltip with day + strength + uncertainty | desktop |
+| `curve-hover.spec.ts`         | Tooltip's day value increases as cursor moves rightward                   | desktop |
+| `curve-hover.spec.ts`         | Pointer-leave hides the tooltip                                           | desktop |
+| `curve-hover.spec.ts`         | Unit toggle flips tooltip strength format (MPa ↔ psi)                     | desktop |
+| `curve-hover.spec.ts`         | Hovering an observation dot shows observation format (not continuous)     | desktop |
+| `curve-hover.spec.ts`         | Mobile: tap on the curve canvas shows a persistent tooltip                | mobile |
 | `header-layout.spec.ts`       | Theme toggle is the rightmost element in the header                       | desktop+mobile |
 | `header-layout.spec.ts`       | On desktop, cite group is to the left of the theme toggle and not overlapping | desktop |
 | `header-layout.spec.ts`       | On mobile, cite group is hidden                                           | mobile |

--- a/test/e2e/curve-hover.spec.ts
+++ b/test/e2e/curve-hover.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Strength-curve continuous hover tooltip + indicator.
+ *
+ * The curve canvas now responds to pointer-move (and pointer-down on touch)
+ * everywhere inside the plot area — not only on the discrete training-data
+ * observation dots. The tooltip shows the predicted strength + uncertainty
+ * at the cursor's time projection. A vertical dashed guide and a dot at
+ * the predicted mean are rendered on the canvas as a visual affordance.
+ *
+ * Two formats coexist on the same `.tooltip` DOM element:
+ *   (1) "Day N: <value> <unit>"           ← cursor on an observation dot
+ *   (2) "Day X.X · <mean> <unit> (±<std>)" ← cursor anywhere else
+ * (1) takes priority via observation hit-test inside the pointer handler.
+ */
+
+const CONTINUOUS_PATTERN = /^Day \d+(?:\.\d)? · [\d,]+(?:\.\d)? (?:psi|MPa) \(±[\d,]+(?:\.\d)?\)$/;
+const OBSERVATION_PATTERN = /^Day \d+(?:\.\d)?: [\d,]+(?:\.\d)? (?:psi|MPa)$/;
+
+async function getCanvasBox(page: import("@playwright/test").Page) {
+  const canvas = page.locator("canvas#curve-canvas");
+  await expect(canvas).toBeVisible();
+  // Wait for the GP to draw so observations + curve are rendered before
+  // any hover tests fire. The home-loads spec already pins this; reproducing
+  // the wait here keeps the test self-contained.
+  await expect
+    .poll(
+      async () =>
+        canvas.evaluate((c: HTMLCanvasElement) => {
+          const ctx = c.getContext("2d");
+          if (!ctx) return false;
+          const data = ctx.getImageData(0, 0, c.width, c.height).data;
+          for (let i = 3; i < data.length; i += 4) if (data[i] !== 0) return true;
+          return false;
+        }),
+      { timeout: 10_000, message: "curve canvas remained blank" },
+    )
+    .toBe(true);
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("canvas has no bounding box");
+  return { canvas, box };
+}
+
+test.describe("strength curve hover tooltip", () => {
+  test("desktop: hovering inside the plot shows continuous tooltip with day + strength + uncertainty", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover-driven UX");
+    await page.goto("/");
+    const { canvas } = await getCanvasBox(page);
+    const tooltip = page.locator(".tooltip");
+
+    // Hover at horizontal midpoint, vertical midpoint
+    await canvas.hover({ position: { x: 200, y: 120 } });
+    await expect(tooltip).toBeVisible();
+    const text = (await tooltip.textContent())?.trim() ?? "";
+    expect(text, `tooltip text = "${text}"`).toMatch(CONTINUOUS_PATTERN);
+  });
+
+  test("desktop: tooltip's day value increases as cursor moves right", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover-driven UX");
+    await page.goto("/");
+    const { canvas, box } = await getCanvasBox(page);
+    const tooltip = page.locator(".tooltip");
+
+    async function dayAt(xPos: number): Promise<number> {
+      await canvas.hover({ position: { x: xPos, y: box.height * 0.5 } });
+      await expect(tooltip).toBeVisible();
+      const text = (await tooltip.textContent()) ?? "";
+      const m = text.match(/Day\s+(\d+(?:\.\d+)?)/);
+      if (!m) throw new Error(`no day in tooltip: "${text}"`);
+      return parseFloat(m[1]);
+    }
+
+    const dayLeft = await dayAt(box.width * 0.25);
+    const dayRight = await dayAt(box.width * 0.75);
+    expect(
+      dayRight,
+      `day at right (${dayRight}) should be > day at left (${dayLeft})`,
+    ).toBeGreaterThan(dayLeft);
+  });
+
+  test("desktop: pointer-leave hides the tooltip", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover-driven UX");
+    await page.goto("/");
+    const { canvas, box } = await getCanvasBox(page);
+    const tooltip = page.locator(".tooltip");
+
+    await canvas.hover({ position: { x: box.width * 0.5, y: box.height * 0.5 } });
+    await expect(tooltip).toBeVisible();
+    // Move the cursor far off-canvas to fire pointerleave.
+    await page.mouse.move(0, 0);
+    await expect(tooltip).toBeHidden();
+  });
+
+  test("desktop: unit toggle flips tooltip strength format (MPa ↔ psi)", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover-driven UX");
+    await page.goto("/");
+    const { canvas, box } = await getCanvasBox(page);
+    const tooltip = page.locator(".tooltip");
+
+    await canvas.hover({ position: { x: box.width * 0.5, y: box.height * 0.5 } });
+    await expect(tooltip).toBeVisible();
+    const before = (await tooltip.textContent()) ?? "";
+    const beforeUnit = /psi/.test(before) ? "psi" : /MPa/.test(before) ? "MPa" : null;
+    expect(beforeUnit, `tooltip "${before}" should mention psi or MPa`).not.toBeNull();
+
+    // Toggle units via the same custom event the toolbar button dispatches.
+    await page.evaluate(() => document.dispatchEvent(new CustomEvent("toggle-units")));
+    // Re-hover to refresh the tooltip in the new unit context (otherwise it
+    // shows pre-toggle text until the next pointermove).
+    await page.mouse.move(0, 0);
+    await canvas.hover({ position: { x: box.width * 0.5, y: box.height * 0.5 } });
+    await expect(tooltip).toBeVisible();
+    const after = (await tooltip.textContent()) ?? "";
+    const afterUnit = beforeUnit === "psi" ? "MPa" : "psi";
+    expect(after, `tooltip "${after}" should now mention ${afterUnit}`).toContain(afterUnit);
+  });
+
+  test("desktop: hovering an observation dot shows observation format (not continuous)", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop hover-driven UX");
+    await page.goto("/");
+    const { canvas } = await getCanvasBox(page);
+    const tooltip = page.locator(".tooltip");
+
+    // Click a Pareto-optimal scatter point to load a training mix, ensuring
+    // observation dots are present on the strength curve canvas.
+    const scatter = page.locator("canvas#scatter-canvas");
+    const scatterBox = await scatter.boundingBox();
+    if (!scatterBox) throw new Error("scatter canvas has no bounding box");
+    await scatter.click({ position: { x: scatterBox.width * 0.3, y: scatterBox.height * 0.3 } });
+    await page.waitForTimeout(800); // animateToComposition + draw
+
+    // Find a real observation dot via the curveObsPositions cache exposed
+    // through window.__test? No — we don't expose it. Instead, walk pixel
+    // candidates and check tooltip text. Try a coarse grid until we hit
+    // observation format.
+    let hitText = "";
+    outer: for (let xPct = 0.1; xPct <= 0.95; xPct += 0.05) {
+      const cb = await canvas.boundingBox();
+      if (!cb) break;
+      for (let yPct = 0.2; yPct <= 0.9; yPct += 0.05) {
+        await canvas.hover({ position: { x: cb.width * xPct, y: cb.height * yPct } });
+        const text = ((await tooltip.textContent()) ?? "").trim();
+        if (OBSERVATION_PATTERN.test(text)) {
+          hitText = text;
+          break outer;
+        }
+      }
+    }
+    expect(
+      hitText,
+      "expected to find an observation hover (format 'Day N: ...') somewhere on the curve",
+    ).toMatch(OBSERVATION_PATTERN);
+    // Observation tooltips do not contain '·' (continuous format does)
+    expect(hitText).not.toContain("·");
+  });
+
+  test("mobile: tap on the curve canvas shows the tooltip", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "mobile", "touch-only behavior");
+    await page.goto("/");
+    const { canvas, box } = await getCanvasBox(page);
+    const tooltip = page.locator(".tooltip");
+
+    // Use the touchscreen API so a real pointerdown event fires (not a
+    // synthesized mouse event). Tap roughly mid-canvas.
+    const targetX = box.x + box.width * 0.5;
+    const targetY = box.y + box.height * 0.5;
+    await page.touchscreen.tap(targetX, targetY);
+
+    // The tooltip must become visible after the tap. Allow a moment for
+    // the pointer event handler to update the DOM.
+    await expect(tooltip).toBeVisible({ timeout: 1000 });
+    const text = (await tooltip.textContent())?.trim() ?? "";
+    expect(text, `mobile tooltip text = "${text}"`).toMatch(/Day \d+(?:\.\d)?/);
+  });
+});


### PR DESCRIPTION
Hovering anywhere inside the strength curve plot (not only on the discrete training-data observation dots) now shows:
  - a vertical dashed guide at the cursor's x;
  - a small dot at the predicted mean strength for that day;
  - a tooltip 'Day X.X · <mean> <unit> (±<std>)' formatted in the active unit system (psi/MPa).

When the cursor is over an actual observation, the existing format 'Day N: <strength> <unit>' takes priority via observation hit-test.

Implementation
- drawStrengthCurve now caches the per-frame geometry (pad, W, H, times, means, stds, sf) on a module-level _lastCurveGeom so the pointer handler can interpolate predictions at the cursor without re-running the GP.
- Helpers: interpolateCurveAtTime() (linear interp on the log-spaced sample arrays), readCurveAt() (canvas-x → reading), and formatStrengthForTooltip() (unit-aware formatting shared by both tooltip modes).
- Pointer events (pointerdown / pointermove / pointerleave / pointercancel) replace the old mouse* listeners so touch input works too. On touch, pointerleave does NOT hide the tooltip — the tap-to-read affordance persists until the user taps off-canvas (handled by a document-level pointerdown listener gated to pointerType === 'touch').

Tests (curve-hover.spec.ts, 6 specs)
- desktop: continuous tooltip appears on hover, format matches 'Day X.X · M unit (±S)'.
- desktop: tooltip's day value increases as cursor moves rightward.
- desktop: pointer-leave hides the tooltip.
- desktop: unit toggle flips between MPa and psi.
- desktop: hovering an observation dot shows observation format, not continuous format.
- mobile: tap on the curve canvas shows a persistent tooltip (uses page.touchscreen.tap).