### PR TITLE
[WIP] iPad landscape: route ≥ 944 px viewports to desktop layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -296,7 +296,7 @@
 
     // On mobile, move sliders content into the unified panel
     function initMobileSliders() {
-      if (mobileSlidersView.children.length === 0 && window.innerWidth <= 1050) {
+      if (mobileSlidersView.children.length === 0 && window.innerWidth <= 900) {
         const hint = slidersPanel.querySelector('.panel-hint');
         const sliders = document.getElementById('sliders');
         if (hint) mobileSlidersView.appendChild(hint);
@@ -305,7 +305,7 @@
     }
     // Restore sliders to their panel for desktop
     function restoreDesktopSliders() {
-      if (window.innerWidth > 1050 && mobileSlidersView.children.length > 0) {
+      if (window.innerWidth > 900 && mobileSlidersView.children.length > 0) {
         const hint = mobileSlidersView.querySelector('.panel-hint');
         const sliders = document.getElementById('sliders');
         const header = slidersPanel.querySelector('.sliders-header');

--- a/docs/style.css
+++ b/docs/style.css
@@ -388,6 +388,20 @@ h2 {
   margin: 0 auto;
 }
 
+/* Tight desktop — narrow iPad-landscape band (e.g. 1024 × 768).
+   Shrink the slider column and tighten gaps/body padding so each chart
+   panel gets ~370 px instead of the cramped ~344 px under desktop sizes.
+   The .layout max-width and panel internals are unchanged. */
+@media (min-width: 901px) and (max-width: 1100px) {
+  .layout {
+    grid-template-columns: 240px 1fr 1fr;
+    gap: 0.5rem;
+  }
+  body {
+    padding: 0 0.6rem 1rem;
+  }
+}
+
 /* Each column flows independently — panels size to content */
 .column-flow {
   display: flex;
@@ -1165,8 +1179,10 @@ a.ref-link {
   opacity: 0.7;
 }
 
-/* Responsive — switch to mobile at 1050px to prevent title/warning overlap in panels */
-@media (max-width: 1050px) {
+/* Responsive — switch to mobile at 900px so iPad landscape (≥ 944 px) keeps
+   the desktop 3-column layout. Below 900 px we stack vertically to prevent
+   title/warning overlap in panels. */
+@media (max-width: 900px) {
   body {
     padding: 0 0.5rem 1rem;
     padding-bottom: env(safe-area-inset-bottom, 1rem);
@@ -1422,7 +1438,7 @@ a.ref-link {
 }
 
 /* Landscape mobile — panels side by side */
-@media (max-width: 1050px) and (orientation: landscape) {
+@media (max-width: 900px) and (orientation: landscape) {
   .layout {
     flex-direction: row;
     flex-wrap: wrap;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,9 +6,11 @@ import { defineConfig, devices } from "@playwright/test";
  * Tests live in test/e2e/*.spec.ts and run against a local http-server
  * serving the docs/ folder.
  *
- * Two projects:
- *   - desktop: 1280×800 Chromium
- *   - mobile:  iPhone 14 emulation (touch + 390×844 viewport)
+ * Three projects:
+ *   - desktop:          1280×800 Chromium
+ *   - mobile:           Pixel 7 emulation (touch + 412×915 viewport)
+ *   - tablet-landscape: iPad (gen 7) landscape (1080×810, touch) — forced
+ *                       onto Chromium so CI doesn't have to install WebKit.
  *
  * Each test runs once per project unless skipped via testInfo.project.name.
  *
@@ -54,6 +56,18 @@ export default defineConfig({
       // matches the engine real Android Chrome users will hit.
       use: {
         ...devices["Pixel 7"],
+      },
+    },
+    {
+      name: "tablet-landscape",
+      // iPad gen 7 (1080 × 810) is representative of the iPad-landscape band:
+      // covers the cramped end (1024 × 768 on gen 5/6/Mini/9) reasonably and
+      // the comfortable end (1194 × 834 on iPad Pro 11) without two projects.
+      // Force Chromium so CI doesn't need a WebKit install — same trade-off as
+      // the mobile project above.
+      use: {
+        ...devices["iPad (gen 7) landscape"],
+        browserName: "chromium",
       },
     },
   ],

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -62,7 +62,24 @@ property on a PR, add a spec for it before merging.
 | `mobile-value-fit.spec.ts`    | Imperial values fit (worst-case mass conversion)                          | mobile |
 | `mobile-value-fit.spec.ts`    | Imperial max-bound values fit                                             | mobile |
 | `mobile-value-fit.spec.ts`    | Narrow viewport (320 px): values fit at all unit/value combinations       | mobile |
+| `ipad-layout.spec.ts`         | Desktop layout active on iPad landscape: `.layout` is a 3-column grid     | tablet-landscape |
+| `ipad-layout.spec.ts`         | Desktop sliders panel visible; mobile-sliders-view hidden                 | tablet-landscape |
+| `ipad-layout.spec.ts`         | No horizontal scroll on iPad landscape                                    | tablet-landscape |
+| `ipad-layout.spec.ts`         | Scatter and strength-curve canvases both visible                          | tablet-landscape |
+| `ipad-layout.spec.ts`         | Tap on inactive Material Source toggle activates it                       | tablet-landscape |
 | `visual-regression.spec.ts`   | Full-page screenshot matches committed baseline (skipped by default)      | desktop+mobile |
+
+## Project matrix
+
+Tests run across three Playwright projects (all on Chromium):
+
+- **desktop** — 1280 × 800
+- **mobile** — Pixel 7 (412 × 915, touch)
+- **tablet-landscape** — iPad (gen 7) landscape (1080 × 810, touch)
+
+Use `testInfo.project.name` (or `test.describe(... )` with `test.skip`) to
+scope a spec to a single project. The iPad-landscape band uses the same
+desktop CSS layout as the desktop project but with touch input enabled.
 
 ## Running
 
@@ -76,6 +93,9 @@ npm run test:e2e
 
 # run only mobile project
 npm run test:e2e -- --project=mobile
+
+# run only the iPad-landscape project
+npm run test:e2e -- --project=tablet-landscape
 
 # headed (watch the browser)
 npm run test:e2e:headed

--- a/test/e2e/ipad-layout.spec.ts
+++ b/test/e2e/ipad-layout.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * iPad-landscape layout invariants.
+ *
+ * The site has two layouts gated by a viewport-width breakpoint in
+ * `docs/style.css` (`@media (max-width: 900px)`). Below 900 px → mobile
+ * stacked layout. ≥ 901 px → desktop 3-column grid.
+ *
+ * iPad in landscape (≥ 944 px on the narrowest modern iPad, 1080 px on gen 7,
+ * 1194 px on iPad Pro 11) should land in the desktop layout. These tests pin
+ * that down on a touch-enabled, iPad-sized viewport and confirm the basic
+ * touch interactions we rely on still work.
+ *
+ * Out of scope (deliberately deferred):
+ *   - scatter canvas hover-preview parity on touch (requires `pointer*`
+ *     events; today's `mousemove` handler is mouse-only).
+ *   - curve-canvas tap-to-show-tooltip persistence (separate change).
+ */
+test.describe("iPad landscape layout", () => {
+  test.beforeEach(({}, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "tablet-landscape",
+      "tablet-landscape only",
+    );
+  });
+
+  test("desktop layout is active: .layout is a grid with 3 columns", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const info = await page.locator(".layout").evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return {
+        display: cs.display,
+        columnCount: cs.gridTemplateColumns.split(/\s+/).filter(Boolean).length,
+      };
+    });
+    expect(info.display).toBe("grid");
+    expect(info.columnCount).toBe(3);
+  });
+
+  test("the desktop sliders panel is visible (mobile would hide it)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.locator(".panel.sliders")).toBeVisible();
+    // The unified mobile panel is hidden on desktop layout.
+    await expect(page.locator(".mobile-sliders-view")).toBeHidden();
+  });
+
+  test("no horizontal scroll", async ({ page }) => {
+    await page.goto("/");
+    const scrollWidth = await page.evaluate(
+      () => document.documentElement.scrollWidth,
+    );
+    const clientWidth = await page.evaluate(
+      () => document.documentElement.clientWidth,
+    );
+    // Allow 1px sub-pixel rounding tolerance — same threshold as
+    // header-layout.spec.ts.
+    expect(scrollWidth - clientWidth).toBeLessThan(2);
+  });
+
+  test("both chart canvases are visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#scatter-canvas")).toBeVisible();
+    await expect(page.locator("#curve-canvas")).toBeVisible();
+  });
+
+  test("tapping the inactive Material Source toggle activates it", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const buttons = page.locator(".material-source-group .toggle-btn");
+    await expect(buttons).toHaveCount(2);
+
+    // Find which button is currently inactive and tap it.
+    const activeIdxBefore = await buttons.evaluateAll((els) =>
+      els.findIndex((el) => el.classList.contains("active")),
+    );
+    expect(activeIdxBefore).toBeGreaterThanOrEqual(0);
+    const inactiveIdx = activeIdxBefore === 0 ? 1 : 0;
+
+    const inactiveBox = await buttons.nth(inactiveIdx).boundingBox();
+    expect(inactiveBox).not.toBeNull();
+    if (!inactiveBox) return;
+
+    // Use touchscreen.tap to mirror real iPad input rather than synthetic
+    // click; verifies the toggle works under touch event ordering too.
+    await page.touchscreen.tap(
+      inactiveBox.x + inactiveBox.width / 2,
+      inactiveBox.y + inactiveBox.height / 2,
+    );
+
+    await expect(buttons.nth(inactiveIdx)).toHaveClass(/active/);
+    await expect(buttons.nth(activeIdxBefore)).not.toHaveClass(/active/);
+  });
+});


### PR DESCRIPTION
Lower the desktop/mobile breakpoint from 1050 px to 900 px so every iPad in landscape (gen 11 944 px → iPad Pro 12.9 1366 px) gets the 3-column desktop grid instead of the stacked mobile layout. iPad portrait (768 px) still falls into the mobile layout, unchanged.

Add a tight-desktop intermediate media query at 901–1100 px that shrinks the slider column from 280 → 240 px, drops the layout gap to 0.5 rem, and trims body padding to 0.6 rem. On a 1024 × 768 iPad standard landscape, each chart panel grows from a cramped ~344 px to ~370 px.

Sync the matching JS breakpoint in docs/index.html (which moves slider content between the desktop sliders panel and the unified mobile panel on resize) from 1050 to 900 so CSS and JS agree on the boundary.

Add a third Playwright project tablet-landscape (iPad gen 7 landscape, 1080 × 810, Chromium with touch enabled) and a new spec test/e2e/ipad-layout.spec.ts pinning down the iPad-landscape invariants: desktop layout active (3-column grid), desktop sliders panel visible, no horizontal scroll, both chart canvases visible, and the Material Source toggle responds to touchscreen.tap.

Update test/e2e/README.md to document the third project and list the new invariants.